### PR TITLE
Fixed Qobuz API usage in getLabelInfo, getPlaylistInfoLabels and getFavoritesInfo.

### DIFF
--- a/QobuzDownloaderX/Helpers/GetInfo.cs
+++ b/QobuzDownloaderX/Helpers/GetInfo.cs
@@ -1,5 +1,7 @@
-﻿using System;
-using QopenAPI;
+﻿using QopenAPI;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace QobuzDownloaderX
 {
@@ -60,10 +62,46 @@ namespace QobuzDownloaderX
         {
             try
             {
-                // Grab label info with auth
+                qbdlxForm._qbdlxForm.logger.Debug("Getting label info...");
                 outputText = null;
-                qbdlxForm._qbdlxForm.logger.Debug("Getting label Info...");
-                QoLabel = QoService.LabelGetWithAuth(app_id, label_id, "albums", 500, 0, user_auth_token);
+
+                int limit = 100;
+                int offset = 0;
+
+                // 1) First request (initial page)
+                QoLabel = QoService.LabelGetWithAuth(app_id, label_id, "albums", limit, offset, user_auth_token);
+
+                if (QoLabel == null || QoLabel.Albums == null || QoLabel.Albums.Items == null)
+                    return QoLabel;
+
+                // Store all collected items here
+                var allItems = QoLabel.Albums.Items.Cast<object>().ToList();
+
+                int total = 0;
+                try { total = QoLabel.Albums.Total; } catch { }
+
+                offset += limit;
+
+                // 2) Pagination loop - keep requesting pages until all items are collected
+                while ((total == 0 && QoLabel.Albums.Items.Count > 0)
+                    || (total > 0 && allItems.Count < total))
+                {
+                    var page = QoService.LabelGetWithAuth(app_id, label_id, "albums", limit, offset, user_auth_token);
+
+                    if (page == null || page.Albums == null || page.Albums.Items == null || page.Albums.Items.Count == 0)
+                        break;
+
+                    // Add items from the page
+                    allItems.AddRange(page.Albums.Items.Cast<object>());
+
+                    offset += limit;
+
+                    if (offset > 1000000) break; // safety cutoff
+                }
+
+                // Deduplicate
+                QoLabel.Albums.Items = allItems.Cast<Item>().GroupBy(a => a.Id).Select(g => g.First()).ToList();
+
                 return QoLabel;
             }
             catch (Exception getLabelInfoEx)
@@ -78,10 +116,77 @@ namespace QobuzDownloaderX
         {
             try
             {
-                // Grab favorites info with auth
-                outputText = null;
                 qbdlxForm._qbdlxForm.logger.Debug("Getting favorites Info...");
-                QoFavorites = QoService.FavoriteGetUserFavoritesWithAuth(app_id, user_id, type, 500, 0, user_auth_token);
+                outputText = null;
+
+                int limit = 100;
+                int offset = 0;
+
+                // 1) First request (initial page)
+                QoFavorites = QoService.FavoriteGetUserFavoritesWithAuth(
+                    app_id, user_id, type, limit, offset, user_auth_token);
+
+                if (QoFavorites == null)
+                    return QoFavorites;
+
+                // Detect the correct list depending on type
+                List<object> allItems;
+
+                if (type == "albums")
+                    allItems = QoFavorites.Albums.Items.Cast<object>().ToList();
+                else if (type == "tracks")
+                    allItems = QoFavorites.Tracks.Items.Cast<object>().ToList();
+                else if (type == "artists")
+                    allItems = QoFavorites.Artists.Items.Cast<object>().ToList();
+                else
+                    return QoFavorites;
+
+                int total = 0;
+                try
+                {
+                    if (type == "albums") total = QoFavorites.Albums.Total;
+                    if (type == "tracks") total = QoFavorites.Tracks.Total;
+                    if (type == "artists") total = QoFavorites.Artists.Total;
+                }
+                catch { }
+
+                offset += limit;
+
+                // 2) Pagination loop - keep requesting pages until all items are collected
+                while (total == 0 || allItems.Count < total)
+                {
+                    var page = QoService.FavoriteGetUserFavoritesWithAuth(
+                        app_id, user_id, type, limit, offset, user_auth_token);
+
+                    if (page == null)
+                        break;
+
+                    List<object> pageItems;
+
+                    if (type == "albums")
+                        pageItems = page.Albums.Items.Cast<object>().ToList();
+                    else if (type == "tracks")
+                        pageItems = page.Tracks.Items.Cast<object>().ToList();
+                    else // artists
+                        pageItems = page.Artists.Items.Cast<object>().ToList();
+
+                    if (pageItems.Count == 0)
+                        break;
+
+                    allItems.AddRange(pageItems);
+
+                    offset += limit;
+                    if (offset > 1000000) break;
+                }
+
+                // Deduplicate
+                if (type == "albums")
+                    QoFavorites.Albums.Items = allItems.Cast<Item>().GroupBy(a => a.Id).Select(g => g.First()).ToList();
+                else if (type == "tracks")
+                    QoFavorites.Tracks.Items = allItems.Cast<Item>().GroupBy(t => t.Id).Select(g => g.First()).ToList();
+                else
+                    QoFavorites.Artists.Items = allItems.Cast<Item>().GroupBy(a => a.Id).Select(g => g.First()).ToList();
+
                 return QoFavorites;
             }
             catch (Exception getFavoritesInfoEx)
@@ -134,10 +239,44 @@ namespace QobuzDownloaderX
         {
             try
             {
-                // Grab playlist info with auth
-                outputText = null;
                 qbdlxForm._qbdlxForm.logger.Debug("Getting playlist Info...");
-                QoPlaylist = QoService.PlaylistGetWithAuth(app_id, playlist_id, "tracks", 500, 0, user_auth_token);
+                outputText = null;
+
+                int limit = 100;
+                int offset = 0;
+
+                // 1) First request (initial page)
+                QoPlaylist = QoService.PlaylistGetWithAuth(app_id, playlist_id, "tracks", limit, offset, user_auth_token);
+
+                if (QoPlaylist == null || QoPlaylist.Tracks == null || QoPlaylist.Tracks.Items == null)
+                    return QoPlaylist;
+
+                var allItems = QoPlaylist.Tracks.Items.Cast<object>().ToList();
+
+                int total = QoPlaylist.Tracks.Total;
+
+                offset += limit;
+
+                // 2) Pagination loop - keep requesting pages until all items are collected
+                while (total == 0 || allItems.Count < total)
+                {
+                    var page = QoService.PlaylistGetWithAuth(app_id, playlist_id, "tracks", limit, offset, user_auth_token);
+
+                    if (page == null || page.Tracks == null || page.Tracks.Items == null)
+                        break;
+
+                    if (page.Tracks.Items.Count == 0)
+                        break;
+
+                    allItems.AddRange(page.Tracks.Items.Cast<object>());
+
+                    offset += limit;
+                    if (offset > 1000000) break;
+                }
+
+                // Deduplicate
+                QoPlaylist.Tracks.Items = allItems.Cast<Item>().GroupBy(t => t.Id).Select(g => g.First()).ToList();
+
                 return QoPlaylist;
             }
             catch (Exception getPlaylistInfoLabelsEx)


### PR DESCRIPTION
_Note: This PR is totally independent from other PRs of mine._

Fixed the Qobuz API usage in functions `getLabelInfo`, `getPlaylistInfoLabels` and `getFavoritesInfo` to collect and return all the items in a page.

That is, no more awkward "500" limit (which doesn't return 500 items anyway). Now the program can properly download an entire label, all tracks from big playlists and all the user's favorites.