### PR TITLE
Replace the three dots in names (...) for a single-char ellipsis (…)

### DIFF
--- a/QobuzDownloaderX/Helpers/RenameTemplates.cs
+++ b/QobuzDownloaderX/Helpers/RenameTemplates.cs
@@ -213,6 +213,9 @@ namespace QobuzDownloaderX
             // Remove any double spaces
             template = Regex.Replace(Regex.Replace(template.Replace("{backslash}", @"\").Replace("{forwardslash}", @"/"), @"\s+", " ").Replace(@" \", @"\"), @"\s+\\", " "); // Replace slash placeholders & remove double spaces
 
+            // Replace long ellipsis
+            template = template.Replace("...", "…");
+            
             qbdlxForm._qbdlxForm.logger.Debug("Template output - " + template);
             return template;
         }


### PR DESCRIPTION
_Note: This PR is totally independent from other PRs of mine._

This simple change automatically replaces the three dots in names (...) for a single-char ellipsis (…), which helps to shorten file and dir name lengths for safety.

You can use the following sample album URLs to test this behavior:
 - https://play.qobuz.com/album/0888880423368
 - https://play.qobuz.com/album/wsvnnbh5o4k0a