### PR TITLE
Better exception handling in getTrackInfoLabels function.

### DIFF
--- a/QobuzDownloaderX/Helpers/GetInfo.cs
+++ b/QobuzDownloaderX/Helpers/GetInfo.cs
@@ -100,8 +100,26 @@ namespace QobuzDownloaderX
                 outputText = null;
                 qbdlxForm._qbdlxForm.logger.Debug("Getting track Info...");
                 QoItem = QoService.TrackGetWithAuth(app_id, track_id, user_auth_token);
-                string album_id = QoItem.Album.Id;
-                QoAlbum = QoService.AlbumGetWithAuth(app_id, album_id, user_auth_token);
+
+                if (QoItem != null)
+                {
+                    if (QoItem.Album != null)
+                    {
+                        string album_id = QoItem.Album.Id;
+                        QoAlbum = QoService.AlbumGetWithAuth(app_id, album_id, user_auth_token);
+                    }
+                    else
+                    {
+                        QoAlbum = null;
+                        qbdlxForm._qbdlxForm.logger.Warning("Track has no associated album.");
+                    }
+                }
+                else
+                {
+                    QoAlbum = null;
+                    qbdlxForm._qbdlxForm.logger.Warning("No track information was retrieved.");
+                }
+
                 return QoItem;
             }
             catch (Exception getTrackInfoLabelsEx)


### PR DESCRIPTION
_Note: This PR is totally independent from other PRs of mine._

Improved exception handling in the `getTrackInfoLabels` function to prevent a NullReferenceException when a track is not available for download.

Previously, the debugger would throw a `NullReferenceException` when `QoItem` or `QoItem.Album` was null. This update adds proper null checks to safely handle tracks without an associated album or tracks that cannot be retrieved.

Example: Problematic track: [Track: Juicy Lucy - Medeski Scofield Martin & Wood](https://open.qobuz.com/track/63227086) in Playlist: https://play.qobuz.com/playlist/22036365

This change is strictly an enhancement to reduce unnecessary debugger interruptions, as the previous original code didn't affected the production build.