### PR TITLE
QoL change with the Ooki dialogs, and a couple of extra improvements.

### DIFF
--- a/QobuzDownloaderX/MainForm/qbdlxForm.Designer.cs
+++ b/QobuzDownloaderX/MainForm/qbdlxForm.Designer.cs
@@ -79,7 +79,7 @@
             this.minimizeButton = new System.Windows.Forms.Button();
             this.aboutPanel = new System.Windows.Forms.Panel();
             this.aboutLabel = new System.Windows.Forms.Label();
-            this.folderBrowser = new System.Windows.Forms.FolderBrowserDialog();
+            this.folderBrowser = new Ookii.Dialogs.WinForms.VistaFolderBrowserDialog();
             this.extraSettingsPanel = new System.Windows.Forms.Panel();
             this.commentLabel = new System.Windows.Forms.Label();
             this.taggingOptionsPanel = new System.Windows.Forms.FlowLayoutPanel();
@@ -703,6 +703,8 @@
             this.downloadFolderTextbox.Size = new System.Drawing.Size(443, 21);
             this.downloadFolderTextbox.TabIndex = 2;
             this.downloadFolderTextbox.Text = "no folder selected";
+            this.downloadFolderTextbox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.downloadFolderTextbox_KeyDown);
+            this.downloadFolderTextbox.KeyUp += new System.Windows.Forms.KeyEventHandler(this.downloadFolderTextbox_KeyUp);
             // 
             // artistTemplateLabel
             // 
@@ -1776,7 +1778,7 @@
         private System.Windows.Forms.Label artistLabel;
         private System.Windows.Forms.TextBox userInfoTextbox;
         private System.Windows.Forms.Label userInfoLabel;
-        public System.Windows.Forms.FolderBrowserDialog folderBrowser;
+        public Ookii.Dialogs.WinForms.VistaFolderBrowserDialog folderBrowser;
         private System.Windows.Forms.Label downloadOptionsLabel;
         private System.Windows.Forms.TextBox downloadFolderTextbox;
         private System.Windows.Forms.Label downloadFolderLabel;

--- a/QobuzDownloaderX/MainForm/qbdlxForm.cs
+++ b/QobuzDownloaderX/MainForm/qbdlxForm.cs
@@ -455,7 +455,41 @@ namespace QobuzDownloaderX
             if (e.KeyCode == Keys.Enter)
             {
                 e.SuppressKeyPress = true;
-                getLinkType();
+                downloadButton.PerformClick();
+            }
+        }
+
+        private void downloadFolderTextbox_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode.Equals(Keys.Enter))
+            {
+                e.SuppressKeyPress = true;
+            }
+        }
+
+        private void downloadFolderTextbox_KeyUp(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Enter)
+            {
+                string path = downloadFolderTextbox.Text?.TrimEnd('\\');
+
+                if (Directory.Exists(path))
+                {
+                    Thread t = new Thread((ThreadStart)(() =>
+                    {
+                        // Save the selection
+                        Settings.Default.savedFolder = path + @"\";
+                        Settings.Default.Save();
+                    }));
+
+                    // Run your code from a thread that joins the STA Thread
+                    t.SetApartmentState(ApartmentState.STA);
+                    t.Start();
+                    t.Join();
+
+                    folderBrowser.SelectedPath = path + @"\";
+                    downloadLocation = path + @"\";
+                }
             }
         }
 
@@ -766,7 +800,7 @@ namespace QobuzDownloaderX
 
         private void openFolderButton_Click(object sender, EventArgs e)
         {
-            // Open selcted folder
+            // Open selected folder
             if (folderBrowser.SelectedPath == null | folderBrowser.SelectedPath == "")
             {
                 // If there's no selected path.
@@ -788,8 +822,10 @@ namespace QobuzDownloaderX
             Thread t = new Thread((ThreadStart)(() =>
             {
                 // Open Folder Browser to select path & Save the selection
+                folderBrowser.ShowNewFolderButton = true;
                 folderBrowser.ShowDialog();
-                Settings.Default.savedFolder = folderBrowser.SelectedPath + @"\";
+                folderBrowser.SelectedPath = folderBrowser.SelectedPath.TrimEnd('\\') + @"\";
+                Settings.Default.savedFolder = folderBrowser.SelectedPath;
                 Settings.Default.Save();
             }));
 
@@ -798,8 +834,8 @@ namespace QobuzDownloaderX
             t.Start();
             t.Join();
             
-            downloadFolderTextbox.Text = folderBrowser.SelectedPath + @"\";
-            downloadLocation = folderBrowser.SelectedPath + @"\";
+            downloadFolderTextbox.Text = folderBrowser.SelectedPath;
+            downloadLocation = folderBrowser.SelectedPath;
         }
 
         private void saveTemplatesButton_Click(object sender, EventArgs e)

--- a/QobuzDownloaderX/QobuzDownloaderX.csproj
+++ b/QobuzDownloaderX/QobuzDownloaderX.csproj
@@ -28,6 +28,8 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -55,9 +57,14 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Bcl.HashCode, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.HashCode.6.0.0\lib\net462\Microsoft.Bcl.HashCode.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Newtonsoft.Json.13.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Ookii.Dialogs.WinForms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=66aa232afad40158, processorArchitecture=MSIL">
+      <HintPath>..\packages\Ookii.Dialogs.WinForms.4.0.0\lib\net462\Ookii.Dialogs.WinForms.dll</HintPath>
     </Reference>
     <Reference Include="policy.2.0.taglib-sharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=db62eba44689b5b0, processorArchitecture=MSIL">
       <HintPath>..\packages\taglib.2.1.0.0\lib\policy.2.0.taglib-sharp.dll</HintPath>
@@ -67,7 +74,34 @@
       <HintPath>..\packages\QopenAPI.0.0.3.4\lib\net48\Qo(penAPI).dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.6.1\lib\net462\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Collections.Immutable, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.10.0.0\lib\net462\System.Collections.Immutable.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Design" />
+    <Reference Include="System.Formats.Nrbf, Version=10.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Formats.Nrbf.10.0.0\lib\net462\System.Formats.Nrbf.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Memory, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.6.3\lib\net462\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.6.1\lib\net462\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reflection.Metadata, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.10.0.0\lib\net462\System.Reflection.Metadata.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Resources.Extensions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Resources.Extensions.10.0.0\lib\net462\System.Resources.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -183,6 +217,13 @@
 xcopy /y /i "$(ProjectDir)Resources\themes.json" "$(TargetDir)"
 </PostBuildEvent>
   </PropertyGroup>
+  <Import Project="..\packages\System.ValueTuple.4.6.1\build\net471\System.ValueTuple.targets" Condition="Exists('..\packages\System.ValueTuple.4.6.1\build\net471\System.ValueTuple.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\System.ValueTuple.4.6.1\build\net471\System.ValueTuple.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.ValueTuple.4.6.1\build\net471\System.ValueTuple.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/QobuzDownloaderX/packages.config
+++ b/QobuzDownloaderX/packages.config
@@ -1,8 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Bcl.HashCode" version="6.0.0" targetFramework="net48" />
   <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net48" />
+  <package id="Ookii.Dialogs.WinForms" version="4.0.0" targetFramework="net48" />
   <package id="QopenAPI" version="0.0.3.4" targetFramework="net48" />
+  <package id="System.Buffers" version="4.6.1" targetFramework="net48" />
+  <package id="System.Collections.Immutable" version="10.0.0" targetFramework="net48" />
+  <package id="System.Formats.Nrbf" version="10.0.0" targetFramework="net48" />
+  <package id="System.Memory" version="4.6.3" targetFramework="net48" />
+  <package id="System.Numerics.Vectors" version="4.6.1" targetFramework="net48" />
+  <package id="System.Reflection.Metadata" version="10.0.0" targetFramework="net48" />
+  <package id="System.Resources.Extensions" version="10.0.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
+  <package id="System.ValueTuple" version="4.6.1" targetFramework="net48" />
   <package id="taglib" version="2.1.0.0" targetFramework="net46" />
   <package id="ZetaLongPaths" version="1.0.17" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
_Note: This PR is totally independent from other PRs of mine._

What I did:

1. Updated all NuGet packages.

2. Added `Ooki.Dialogs.WinForms` package.

3. Replaced the prehistoric and annoying `FolderBrowserDialog` with an `Ookii.Dialogs.WinForms.VistaFolderBrowserDialog`:

<img width="946" height="533" alt="WinSnap 01" src="https://github.com/user-attachments/assets/2acc0d24-4423-4a36-9560-8824c6f68f4b" />

4. Fixed a visual issue in `selectFolderButton_Click` event handler that was appending additional backslash characters.

5. Added logic through `downloadFolderTextbox_KeyUp` event handler to set the download folder via Enter key (if the directory path exists).

    Suggestion: maybe pop-up a `MessageBox` after pressing Enter key if the path doesn't exists to warn the end-user?. This also may require a new string to translate.

6. Fixed a typo in a comment-line in `openFolderButton_Click` event handler.

7. `inputTextbox_KeyDown` event handler now triggers a click (`downloadButton.PerformClick()`) on the "**GET**" button instead of calling the `getLinkType` function directly. This is especially important in relation to a previous PR: https://github.com/ImAiiR/QobuzDownloaderX/pull/229 and for what I've said there:

>  5. The "**GET**" button and the associated textbox are now temporarily disabled while a download operation is running:
> 
> This avoids awkward behavior in the application if the user click the button twice while a download is running.