### PR TITLE
Harden credential/path handling, fix runtime startup, and improve stream fallback

### DIFF
--- a/QobuzDownloaderX/App.config
+++ b/QobuzDownloaderX/App.config
@@ -11,6 +11,14 @@
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
+    <runtime>
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+            <dependentAssembly>
+                <assemblyIdentity name="System.Resources.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-10.0.0.2" newVersion="10.0.0.2" />
+            </dependentAssembly>
+        </assemblyBinding>
+    </runtime>
     <userSettings>
         <QobuzDownloaderX.Properties.Settings>
             <setting name="savedFolder" serializeAs="String">

--- a/QobuzDownloaderX/Helpers/BufferedLogger.cs
+++ b/QobuzDownloaderX/Helpers/BufferedLogger.cs
@@ -45,7 +45,8 @@ namespace QobuzDownloaderX.Helpers
 
         private void WriteLog(string level, string message)
         {
-            var logMessage = $"[{DateTime.Now}] [{level}] {message}";
+            string sanitizedMessage = SecurityHelpers.RedactSensitiveData(message);
+            var logMessage = $"[{DateTime.Now}] [{level}] {sanitizedMessage}";
 
             lock (_lock) // Thread-safety
             {
@@ -60,7 +61,7 @@ namespace QobuzDownloaderX.Helpers
                     this.RotateToNewLogFileIfNeeded();
 
                     // Write to console immediately
-                    System.Diagnostics.Debug.WriteLine($"{level} | {message}");
+                    System.Diagnostics.Debug.WriteLine($"{level} | {sanitizedMessage}");
 
                     // Add to buffer
                     _buffer.AppendLine(logMessage);

--- a/QobuzDownloaderX/Helpers/Download/DownloadAlbum.cs
+++ b/QobuzDownloaderX/Helpers/Download/DownloadAlbum.cs
@@ -45,8 +45,10 @@ namespace QobuzDownloaderX
             }
         }
 
-        private async Task DownloadGoodiesAsync(string downloadPath, Album album, CancellationToken abortToken)
+        private async Task<bool> DownloadGoodiesAsync(string downloadPath, Album album, CancellationToken abortToken)
         {
+            bool allSuccessful = true;
+
             foreach (var goody in album.Goodies)
             {
                 try
@@ -57,6 +59,7 @@ namespace QobuzDownloaderX
                 {
                     qbdlxForm._qbdlxForm.logger.Warning("No URL found for the goody, skipping.");
                     getInfo.updateDownloadOutput($"\r\n{qbdlxForm._qbdlxForm.downloadOutputGoodyNoURL}\r\n");
+                    allSuccessful = false;
                     continue;
                 }
 
@@ -65,20 +68,26 @@ namespace QobuzDownloaderX
                 catch
                 {
                     qbdlxForm._qbdlxForm.logger.Warning("No goodies found or failed to download");
+                    allSuccessful = false;
                 }
             }
+
+            return allSuccessful;
         }
 
-        internal async Task DownloadTracksAsync(string app_id, string album_id, string format_id, string audio_format, string user_auth_token, string app_secret, string downloadLocation, string artistTemplate, string albumTemplate, string trackTemplate, Album album, IProgress<int> progress, IProgress<(int current, int total)> trackCounter, DownloadStats stats, CancellationToken abortToken)
+        internal async Task<bool> DownloadTracksAsync(string app_id, string album_id, string format_id, string audio_format, string user_auth_token, string app_secret, string downloadLocation, string artistTemplate, string albumTemplate, string trackTemplate, Album album, IProgress<int> progress, IProgress<(int current, int total)> trackCounter, DownloadStats stats, CancellationToken abortToken)
         {
             int totalTracks = album.Tracks.Items.Count;
             int trackIndex = 0;
+            bool allSuccessful = true;
+            bool albumSkipped = false;
 
             foreach (var item in album.Tracks.Items)
             {
                 if (abortToken.IsCancellationRequested) { abortToken.ThrowIfCancellationRequested(); }
                 if (qbdlxForm.skipCurrentAlbum) {
                     qbdlxForm.skipCurrentAlbum = false;
+                    albumSkipped = true;
                     qbdlxForm._qbdlxForm.logger.Debug("Skipping current album by user");
                     getInfo.updateDownloadOutput(qbdlxForm._qbdlxForm.albumSkipped);
                     break; }
@@ -97,16 +106,21 @@ namespace QobuzDownloaderX
                     });
 
                     var trackInfo = QoService.TrackGetWithAuth(app_id, item.Id.ToString(), user_auth_token);
-                    await downloadTrack.DownloadTrackAsync(
+                    bool trackSucceeded = await downloadTrack.DownloadTrackAsync(
                         "album", app_id, album_id, format_id, audio_format, 
                         user_auth_token, app_secret, downloadLocation, artistTemplate, albumTemplate, 
                         trackTemplate, album, trackInfo, trackProgress, stats, abortToken);
+                    if (!trackSucceeded)
+                    {
+                        allSuccessful = false;
+                    }
 
                 }
                 catch (Exception ex)
                 {
                     qbdlxForm._qbdlxForm.logger.Error($"Track {item.Id} failed: {ex}");
                     getInfo.updateDownloadOutput($"\r\n{ex}");
+                    allSuccessful = false;
                 }
                 finally
                 {
@@ -120,9 +134,10 @@ namespace QobuzDownloaderX
                 }
             }
             qbdlxForm.skipCurrentAlbum = false;
+            return allSuccessful && !albumSkipped;
         }
 
-        internal async Task DownloadAlbumAsync(string app_id, string album_id, string format_id, string audio_format, string user_auth_token, string app_secret, string downloadLocation, string artistTemplate, string albumTemplate, string trackTemplate, Album QoAlbum, IProgress<int> progress, IProgress<(int current, int total)> trackCounter, DownloadStats stats, CancellationToken abortToken)
+        internal async Task<bool> DownloadAlbumAsync(string app_id, string album_id, string format_id, string audio_format, string user_auth_token, string app_secret, string downloadLocation, string artistTemplate, string albumTemplate, string trackTemplate, Album QoAlbum, IProgress<int> progress, IProgress<(int current, int total)> trackCounter, DownloadStats stats, CancellationToken abortToken)
         {
             qbdlxForm._qbdlxForm.logger.Debug("Starting album download (downloadAlbum)");
 
@@ -139,9 +154,8 @@ namespace QobuzDownloaderX
                     qbdlxForm._qbdlxForm.logger.Debug("Streamable tag is set to false on Qobuz, and streamable check is enabled, skipping download");
                     getInfo.updateDownloadOutput(qbdlxForm._qbdlxForm.downloadOutputAlNotStream);
                     Miscellaneous.LogNotStreamableAlbumEntry(downloadLocation, QoAlbum, qbdlxForm._qbdlxForm.downloadOutputAlNotStream);
-                    getInfo.updateDownloadOutput("\r\n" + qbdlxForm._qbdlxForm.downloadOutputCompleted);
                     progress?.Report(100);
-                    return;
+                    return false;
                 }
                 else
                 {
@@ -154,7 +168,7 @@ namespace QobuzDownloaderX
             {
                 // Find the how many characters are needed for padding
                 paddedTrackLength = padNumber.padTracks(QoAlbum);
-                paddedDiscLength = padNumber.padTracks(QoAlbum);
+                paddedDiscLength = padNumber.padDiscs(QoAlbum);
 
                 // Set download path
                 downloadPath = await downloadFile.createPath(downloadLocation, artistTemplate, albumTemplate, trackTemplate, null, null, paddedTrackLength, paddedDiscLength, QoAlbum, null, null);
@@ -165,7 +179,7 @@ namespace QobuzDownloaderX
                 if (abortToken.IsCancellationRequested) { abortToken.ThrowIfCancellationRequested(); }
 
                 // Download tracks
-                await DownloadTracksAsync(
+                bool tracksSucceeded = await DownloadTracksAsync(
                     app_id, album_id, format_id, audio_format, user_auth_token, app_secret, downloadLocation, 
                     artistTemplate, albumTemplate, trackTemplate, QoAlbum, progress, trackCounter, stats, abortToken);
 
@@ -175,13 +189,14 @@ namespace QobuzDownloaderX
                 getInfo.outputText = qbdlxForm._qbdlxForm.downloadOutput.Text;
 
                 // Download goodies
+                bool goodiesSucceeded = true;
                 if (abortToken.IsCancellationRequested) { 
                     abortToken.ThrowIfCancellationRequested(); 
                 } else
                 {
                     if (Settings.Default.downloadGoodies)
                     {
-                        await DownloadGoodiesAsync(downloadPath, QoAlbum, abortToken);
+                        goodiesSucceeded = await DownloadGoodiesAsync(downloadPath, QoAlbum, abortToken);
                     }
                 }
 
@@ -196,12 +211,13 @@ namespace QobuzDownloaderX
                 qbdlxForm._qbdlxForm.logger.Debug("All downloads completed!");
 
                 progress?.Report(100);
+                return tracksSucceeded && goodiesSucceeded;
             }
             catch (Exception downloadAlbumEx)
             {
                 qbdlxForm._qbdlxForm.logger.Error("Error occured during downloadAlbum, error below:\r\n" + downloadAlbumEx);
                 Debug.WriteLine(downloadAlbumEx);
-                return;
+                return false;
             }
             finally
             {

--- a/QobuzDownloaderX/Helpers/Download/DownloadFile.cs
+++ b/QobuzDownloaderX/Helpers/Download/DownloadFile.cs
@@ -34,7 +34,21 @@ namespace QobuzDownloaderX
         public string embeddedArtworkPath { get; set; }
 
         [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "I don’t feel like changing this and it doesn’t matter")]
-        public async Task<string> createPath(string downloadLocation, string artistTemplate, string albumTemplate, string trackTemplate, string playlistTemplate, string favoritesTemplate, int paddedTrackLength, int paddedDiscLength, Album QoAlbum, Item QoItem, Playlist QoPlaylist)
+        public async Task<string> createPath(
+            string downloadLocation,
+            string artistTemplate,
+            string albumTemplate,
+            string trackTemplate,
+            string playlistTemplate,
+            string favoritesTemplate,
+            int paddedTrackLength,
+            int paddedDiscLength,
+            Album QoAlbum,
+            Item QoItem,
+            Playlist QoPlaylist,
+            string effectiveFormatId = null,
+            int? effectiveBitDepth = null,
+            double? effectiveSamplingRate = null)
         {
             return await Task.Run(() =>
             {
@@ -42,24 +56,25 @@ namespace QobuzDownloaderX
                 if (QoPlaylist == null)
                 {
                     qbdlxForm._qbdlxForm.logger.Debug("Using non-playlist path");
-                    string artistTemplateConverted = renameTemplates.renameTemplates(artistTemplate, paddedTrackLength, paddedDiscLength, qbdlxForm._qbdlxForm.audio_format, QoAlbum, null, null);
-                    string albumTemplateConverted = renameTemplates.renameTemplates(albumTemplate, paddedTrackLength, paddedDiscLength, qbdlxForm._qbdlxForm.audio_format, QoAlbum, null, null);
+                    string artistTemplateConverted = renameTemplates.renameTemplates(artistTemplate, paddedTrackLength, paddedDiscLength, qbdlxForm._qbdlxForm.audio_format, QoAlbum, null, null, effectiveFormatId, effectiveBitDepth, effectiveSamplingRate);
+                    string albumTemplateConverted = renameTemplates.renameTemplates(albumTemplate, paddedTrackLength, paddedDiscLength, qbdlxForm._qbdlxForm.audio_format, QoAlbum, null, null, effectiveFormatId, effectiveBitDepth, effectiveSamplingRate);
                     downloadPath = ZlpPathHelper.Combine(downloadLocation, artistTemplateConverted, albumTemplateConverted.TrimEnd(ZlpPathHelper.DirectorySeparatorChar) + ZlpPathHelper.DirectorySeparatorChar);                    
                 }
                 else
                 {
                     qbdlxForm._qbdlxForm.logger.Debug("Using playlist path");
-                    string playlistTemplateConverted = renameTemplates.renameTemplates(playlistTemplate, paddedTrackLength, paddedDiscLength, qbdlxForm._qbdlxForm.audio_format, QoAlbum, QoItem, QoPlaylist);
+                    string playlistTemplateConverted = renameTemplates.renameTemplates(playlistTemplate, paddedTrackLength, paddedDiscLength, qbdlxForm._qbdlxForm.audio_format, QoAlbum, QoItem, QoPlaylist, effectiveFormatId, effectiveBitDepth, effectiveSamplingRate);
                     downloadPath = ZlpPathHelper.Combine(downloadLocation, playlistTemplateConverted.TrimEnd(ZlpPathHelper.DirectorySeparatorChar) + ZlpPathHelper.DirectorySeparatorChar);
                 }
                 downloadPath = RenameTemplates.spacesRegex.Replace(downloadPath, " "); // Remove double spaces
-                return downloadPath;
+                downloadPath = SecurityHelpers.EnsurePathIsWithinRoot(downloadLocation, downloadPath, nameof(downloadPath));
+                return SecurityHelpers.EnsureTrailingDirectorySeparator(downloadPath);
             });
         }
 
         public async Task DownloadStream(string downloadType, string streamUrl, string downloadPath, string filePath, string audio_format, Album QoAlbum, Item QoItem, GetInfo getInfo, CancellationToken abortToken, DownloadStats stats)
         {
-            const string tempDir = @"qbdlx-temp";
+            string tempDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "qbdlx-temp");
             string tempFile = ZlpPathHelper.Combine(tempDir, $"qbdlx_downloading-{QoItem.Id}{audio_format}");
 
             // Ensure temp directory exists
@@ -105,7 +120,7 @@ namespace QobuzDownloaderX
 
             // Handle subfolders if more than 1 volume
             string finalDownloadPath = downloadPath;
-            if (QoItem.PlaylistTrackId is null && !(downloadType=="track") && QoAlbum.MediaCount > 1)
+            if (QoItem.PlaylistTrackId is null && !(downloadType == "track") && QoAlbum.MediaCount > 1)
             {
                 if (!string.IsNullOrWhiteSpace(Settings.Default.savedCdTemplate))
                 {
@@ -115,25 +130,22 @@ namespace QobuzDownloaderX
                     finalDownloadPath = ZlpPathHelper.Combine(downloadPath, cdDirectoryName);
                     // Previous, original logic:
                     // finalDownloadPath = ZlpPathHelper.Combine(downloadPath, "CD " + QoItem.MediaNumber.ToString().PadLeft(paddingNumbers.padDiscs(QoAlbum), '0'));
-
-                    ZlpIOHelper.CreateDirectory(finalDownloadPath);
                 }
             }
-            else
-            {
-                ZlpIOHelper.CreateDirectory(ZlpPathHelper.GetDirectoryPathNameFromFilePath(downloadPath));
-            }
+
+            ZlpIOHelper.CreateDirectory(finalDownloadPath);
 
             try
             {
-                qbdlxForm._qbdlxForm.logger.Debug("Stream URL: " + streamUrl);
+                Uri streamUri = SecurityHelpers.RequireHttpsUrl(streamUrl, "Stream");
+                qbdlxForm._qbdlxForm.logger.Debug("Stream URL: " + streamUri.GetLeftPart(UriPartial.Path));
 
                 TimeSpan selectedTimeout = audio_format?.ToLowerInvariant() == ".mp3"
                     ? mp3TrackDownloadCompletionTimeout
                     : flacTrackDownloadCompletionTimeout;
 
                 using (var httpClient = new HttpClient { Timeout = selectedTimeout })
-                using (var response = await httpClient.GetAsync(streamUrl, HttpCompletionOption.ResponseHeadersRead))
+                using (var response = await httpClient.GetAsync(streamUri, HttpCompletionOption.ResponseHeadersRead))
                 {
                     response.EnsureSuccessStatusCode();
 
@@ -248,7 +260,7 @@ namespace QobuzDownloaderX
                         string name = Path.GetFileNameWithoutExtension(filePath);
                         string safeNameTruncated = RenameTemplates.TruncateLongName(name, (Byte)" (999)".Length);
                         string ext = Path.GetExtension(filePath);
-                        string safeFullPathTruncated = Path.Combine(dir, name + ext);
+                        string safeFullPathTruncated = Path.Combine(dir, safeNameTruncated + ext);
 
                         string duplicateFileName = Miscellaneous.GetDuplicateFileName(safeFullPathTruncated);
                         ZlpIOHelper.MoveFile(tempFile, duplicateFileName, overwriteExisting: true);
@@ -345,15 +357,17 @@ namespace QobuzDownloaderX
             using (var downloadTimeoutCts = new CancellationTokenSource(artworkDownloadCompletionTimeout))
             {
                 qbdlxForm._qbdlxForm.logger.Debug("Downloading Cover Art");
-                ZlpIOHelper.CreateDirectory(ZlpPathHelper.GetDirectoryPathNameFromFilePath(downloadPath));
+                ZlpIOHelper.CreateDirectory(downloadPath);
 
                 // Helper local function for downloading with dual timeouts
                 async Task DownloadWithTimeoutAsync(string url, string destinationPath)
                 {
                     try
                     {
+                        Uri downloadUri = SecurityHelpers.RequireHttpsUrl(url, "Artwork");
+
                         using (var response = await httpClient.GetAsync(
-                            url,
+                            downloadUri,
                             HttpCompletionOption.ResponseHeadersRead,
                             downloadTimeoutCts.Token))
                         {
@@ -396,7 +410,7 @@ namespace QobuzDownloaderX
                     {
                         qbdlxForm._qbdlxForm.logger.Debug("Saved artwork Cover.jpg not found, downloading");
                         string url = QoAlbum.Image.Large.Replace("_600", "_" + qbdlxForm._qbdlxForm.savedArtSize);
-                        string dest = ZlpPathHelper.GetFullPath(downloadPath + @"Cover.jpg");
+                        string dest = SecurityHelpers.EnsurePathIsWithinRoot(downloadPath, Path.Combine(downloadPath, "Cover.jpg"), "artworkPath");
                         await DownloadWithTimeoutAsync(url, dest);
                     }
                 }
@@ -415,11 +429,19 @@ namespace QobuzDownloaderX
 
         public async Task DownloadGoody(string downloadPath, Album QoAlbum, Goody QoGoody, GetInfo getInfo, CancellationToken abortToken)
         {
-            ZlpIOHelper.CreateDirectory(ZlpPathHelper.GetDirectoryPathNameFromFilePath(downloadPath));
+            ZlpIOHelper.CreateDirectory(downloadPath);
 
-            string fileName = downloadPath
-                              + renameTemplates.GetSafeFilename(QoGoody.Description ?? QoAlbum.Title)
-                              + " (" + QoGoody.Id + $"){Path.GetExtension(QoGoody.Url)}";
+            Uri goodyUri = SecurityHelpers.RequireHttpsUrl(QoGoody.Url, "Goody");
+            string goodyExtension = Path.GetExtension(goodyUri.AbsolutePath);
+            if (string.IsNullOrWhiteSpace(goodyExtension))
+            {
+                goodyExtension = ".bin";
+            }
+
+            string fileName = Path.Combine(
+                downloadPath,
+                renameTemplates.GetSafeFilename(QoGoody.Description ?? QoAlbum.Title) + " (" + QoGoody.Id + ")" + goodyExtension);
+            fileName = SecurityHelpers.EnsurePathIsWithinRoot(downloadPath, fileName, nameof(fileName));
 
             if (ZlpIOHelper.FileExists(fileName))
             {
@@ -442,7 +464,7 @@ namespace QobuzDownloaderX
                         var buffer = new byte[bufferLength];
 
                         using (var response = await httpClient.GetAsync(
-                            QoGoody.Url,
+                            goodyUri,
                             HttpCompletionOption.ResponseHeadersRead,
                             downloadTimeoutCts.Token))
                         {

--- a/QobuzDownloaderX/Helpers/Download/DownloadFile.cs
+++ b/QobuzDownloaderX/Helpers/Download/DownloadFile.cs
@@ -33,6 +33,21 @@ namespace QobuzDownloaderX
 
         public string embeddedArtworkPath { get; set; }
 
+        private static void CleanupTempFile(string tempFile)
+        {
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(tempFile) && File.Exists(tempFile))
+                {
+                    File.Delete(tempFile);
+                }
+            }
+            catch
+            {
+                // Best-effort cleanup only.
+            }
+        }
+
         [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "I don’t feel like changing this and it doesn’t matter")]
         public async Task<string> createPath(
             string downloadLocation,
@@ -46,6 +61,7 @@ namespace QobuzDownloaderX
             Album QoAlbum,
             Item QoItem,
             Playlist QoPlaylist,
+            string effectiveAudioFormat = null,
             string effectiveFormatId = null,
             int? effectiveBitDepth = null,
             double? effectiveSamplingRate = null)
@@ -53,17 +69,18 @@ namespace QobuzDownloaderX
             return await Task.Run(() =>
             {
                 string downloadPath;
+                string pathAudioFormat = effectiveAudioFormat ?? qbdlxForm._qbdlxForm.audio_format;
                 if (QoPlaylist == null)
                 {
                     qbdlxForm._qbdlxForm.logger.Debug("Using non-playlist path");
-                    string artistTemplateConverted = renameTemplates.renameTemplates(artistTemplate, paddedTrackLength, paddedDiscLength, qbdlxForm._qbdlxForm.audio_format, QoAlbum, null, null, effectiveFormatId, effectiveBitDepth, effectiveSamplingRate);
-                    string albumTemplateConverted = renameTemplates.renameTemplates(albumTemplate, paddedTrackLength, paddedDiscLength, qbdlxForm._qbdlxForm.audio_format, QoAlbum, null, null, effectiveFormatId, effectiveBitDepth, effectiveSamplingRate);
+                    string artistTemplateConverted = renameTemplates.renameTemplates(artistTemplate, paddedTrackLength, paddedDiscLength, pathAudioFormat, QoAlbum, null, null, effectiveFormatId, effectiveBitDepth, effectiveSamplingRate);
+                    string albumTemplateConverted = renameTemplates.renameTemplates(albumTemplate, paddedTrackLength, paddedDiscLength, pathAudioFormat, QoAlbum, null, null, effectiveFormatId, effectiveBitDepth, effectiveSamplingRate);
                     downloadPath = ZlpPathHelper.Combine(downloadLocation, artistTemplateConverted, albumTemplateConverted.TrimEnd(ZlpPathHelper.DirectorySeparatorChar) + ZlpPathHelper.DirectorySeparatorChar);                    
                 }
                 else
                 {
                     qbdlxForm._qbdlxForm.logger.Debug("Using playlist path");
-                    string playlistTemplateConverted = renameTemplates.renameTemplates(playlistTemplate, paddedTrackLength, paddedDiscLength, qbdlxForm._qbdlxForm.audio_format, QoAlbum, QoItem, QoPlaylist, effectiveFormatId, effectiveBitDepth, effectiveSamplingRate);
+                    string playlistTemplateConverted = renameTemplates.renameTemplates(playlistTemplate, paddedTrackLength, paddedDiscLength, pathAudioFormat, QoAlbum, QoItem, QoPlaylist, effectiveFormatId, effectiveBitDepth, effectiveSamplingRate);
                     downloadPath = ZlpPathHelper.Combine(downloadLocation, playlistTemplateConverted.TrimEnd(ZlpPathHelper.DirectorySeparatorChar) + ZlpPathHelper.DirectorySeparatorChar);
                 }
                 downloadPath = RenameTemplates.spacesRegex.Replace(downloadPath, " "); // Remove double spaces
@@ -72,7 +89,7 @@ namespace QobuzDownloaderX
             });
         }
 
-        public async Task DownloadStream(string downloadType, string streamUrl, string downloadPath, string filePath, string audio_format, Album QoAlbum, Item QoItem, GetInfo getInfo, CancellationToken abortToken, DownloadStats stats)
+        public async Task<bool> DownloadStream(string downloadType, string streamUrl, string downloadPath, string filePath, string audio_format, Album QoAlbum, Item QoItem, GetInfo getInfo, CancellationToken abortToken, DownloadStats stats)
         {
             string tempDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "qbdlx-temp");
             string tempFile = ZlpPathHelper.Combine(tempDir, $"qbdlx_downloading-{QoItem.Id}{audio_format}");
@@ -99,7 +116,7 @@ namespace QobuzDownloaderX
                 {
                     qbdlxForm._qbdlxForm.logger.Error("Temp directory is not writable: " + ex.Message);
                     getInfo.updateDownloadOutput($"ERROR: Temp directory '{tempDir}' is not writable: {ex.Message}\r\n");
-                    throw;
+                    return false;
                 }
             }
 
@@ -273,14 +290,20 @@ namespace QobuzDownloaderX
 
                 qbdlxForm._qbdlxForm.logger.Debug("DownloadStream complete.");
                 getInfo.updateDownloadOutput($" {qbdlxForm._qbdlxForm.downloadOutputDone}\r\n");
+                return true;
+            }
+            catch (OperationCanceledException) when (abortToken.IsCancellationRequested)
+            {
+                CleanupTempFile(tempFile);
+                throw;
             }
             catch (TaskCanceledException ex)
             {
                 string msg = "DownloadStream timed out (TaskCanceledException): " + ex.Message;
                 qbdlxForm._qbdlxForm.logger.Error(msg);
                 Miscellaneous.LogFailedDownloadStreamEntry(Path.GetDirectoryName(filePath), QoItem, msg);
-                throw;
-
+                CleanupTempFile(tempFile);
+                return false;
             }
             catch (OperationCanceledException ex)
             {
@@ -289,8 +312,12 @@ namespace QobuzDownloaderX
                     string msg = "DownloadStream canceled (OperationCanceledException): " + ex.Message;
                     qbdlxForm._qbdlxForm.logger.Error(msg);
                     Miscellaneous.LogFailedDownloadStreamEntry(Path.GetDirectoryName(filePath), QoItem, msg);
-                    throw;
+                    CleanupTempFile(tempFile);
+                    return false;
                 }
+
+                CleanupTempFile(tempFile);
+                throw;
             }
             catch (WebException webEx)
             {
@@ -298,6 +325,8 @@ namespace QobuzDownloaderX
                 qbdlxForm._qbdlxForm.logger.Error(msg);
                 Miscellaneous.LogFailedDownloadStreamEntry(Path.GetDirectoryName(filePath), QoItem, msg);
                 getInfo.updateDownloadOutput(msg);
+                CleanupTempFile(tempFile);
+                return false;
             }
             catch (Exception ex) when (
                   (ex is IOException ioEx && ioEx.HResult == unchecked((int)0x80070070)) ||
@@ -339,14 +368,17 @@ namespace QobuzDownloaderX
                     qbdlxForm._qbdlxForm.logger.Error(msg);
                     Miscellaneous.LogFailedDownloadStreamEntry(Path.GetDirectoryName(filePath), QoItem, msg);
                 }
-                throw; // rethrow original exception
+
+                CleanupTempFile(tempFile);
+                return false;
             }
             catch (Exception ex)
             {
                 string msg = "DownloadStream failed (Exception): " + ex.Message;
                 qbdlxForm._qbdlxForm.logger.Error(msg);
                 Miscellaneous.LogFailedDownloadStreamEntry(Path.GetDirectoryName(filePath), QoItem, msg);
-                throw;
+                CleanupTempFile(tempFile);
+                return false;
             }
         }
 

--- a/QobuzDownloaderX/Helpers/Download/DownloadTrack.cs
+++ b/QobuzDownloaderX/Helpers/Download/DownloadTrack.cs
@@ -1,4 +1,4 @@
-﻿using QobuzDownloaderX.Helpers;
+using QobuzDownloaderX.Helpers;
 using QobuzDownloaderX.Properties;
 using QopenAPI;
 using System;
@@ -31,6 +31,101 @@ namespace QobuzDownloaderX
         // readonly FixMD5 fixMD5 = new FixMD5(); // UNUSED
 
         public void clearOutputText() => getInfo.outputText = null;
+
+        private sealed class ResolvedStreamSelection
+        {
+            public QopenAPI.Stream Stream { get; set; }
+            public string EffectiveFormatId { get; set; }
+            public string EffectiveAudioFormat { get; set; }
+            public int? EffectiveBitDepth { get; set; }
+            public double? EffectiveSamplingRate { get; set; }
+        }
+
+        private static string[] GetFormatFallbackChain(string requestedFormatId)
+        {
+            switch (requestedFormatId)
+            {
+                case "27":
+                    return new[] { "27", "7", "6" };
+                case "7":
+                    return new[] { "7", "6" };
+                case "6":
+                case "5":
+                    return new[] { requestedFormatId };
+                default:
+                    return new[] { requestedFormatId };
+            }
+        }
+
+        private static string GetAudioFormatFromMimeType(string mimeType, string fallbackAudioFormat)
+        {
+            if (mimeType != null)
+            {
+                if (mimeType.IndexOf("flac", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return ".flac";
+                }
+
+                if (mimeType.IndexOf("mpeg", StringComparison.OrdinalIgnoreCase) >= 0
+                    || mimeType.IndexOf("mp3", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return ".mp3";
+                }
+            }
+
+            return fallbackAudioFormat;
+        }
+
+        private ResolvedStreamSelection ResolveBestAvailableStream(string app_id, string requestedFormatId, string user_auth_token, string app_secret, Item qoItem, string fallbackAudioFormat)
+        {
+            foreach (string candidateFormatId in GetFormatFallbackChain(requestedFormatId))
+            {
+                try
+                {
+                    var qoStream = QoService.TrackGetFileUrl(qoItem.Id.ToString(), candidateFormatId, app_id, user_auth_token, app_secret);
+                    if (qoStream == null || string.IsNullOrWhiteSpace(qoStream.StreamURL))
+                    {
+                        continue;
+                    }
+
+                    SecurityHelpers.RequireHttpsUrl(qoStream.StreamURL, "Stream");
+
+                    int? bitDepth = SecurityHelpers.TryParseInt(qoStream.BitDepth, out int parsedBitDepth)
+                        ? parsedBitDepth
+                        : (int?)null;
+
+                    double? samplingRate = SecurityHelpers.TryParseDouble(qoStream.SampleRate, out double parsedSampleRate)
+                        ? parsedSampleRate
+                        : (double?)null;
+
+                    string effectiveFormatId = qoStream.FormatID > 0
+                        ? qoStream.FormatID.ToString()
+                        : candidateFormatId;
+
+                    if (!string.Equals(effectiveFormatId, requestedFormatId, StringComparison.Ordinal))
+                    {
+                        qbdlxForm._qbdlxForm.logger.Warning(
+                            $"Requested format {requestedFormatId} was unavailable for track {qoItem.Id}; using format {effectiveFormatId} instead.");
+                    }
+
+                    return new ResolvedStreamSelection
+                    {
+                        Stream = qoStream,
+                        EffectiveFormatId = effectiveFormatId,
+                        EffectiveAudioFormat = GetAudioFormatFromMimeType(qoStream.MimeType, fallbackAudioFormat),
+                        EffectiveBitDepth = bitDepth,
+                        EffectiveSamplingRate = samplingRate
+                    };
+                }
+                catch (Exception ex)
+                {
+                    qbdlxForm._qbdlxForm.logger.Warning(
+                        $"Failed to resolve track stream for track {qoItem.Id} with format {candidateFormatId}: {ex.Message}");
+                }
+            }
+
+            return null;
+        }
 
         private bool VerifyStreamable(Item QoItem, int paddedTrackLength)
         {
@@ -74,11 +169,11 @@ namespace QobuzDownloaderX
             }
         }
 
-        private async Task DownloadAndSaveTrack(string downloadType, string app_id, string format_id, string user_auth_token, string app_secret, Album QoAlbum, Item QoItem, Playlist QoPlaylist, string downloadPath, string filePath, string audio_format, int paddedTrackLength, DownloadStats stats, CancellationToken abortToken)
+        private async Task DownloadAndSaveTrack(string downloadType, ResolvedStreamSelection resolvedStream, Album QoAlbum, Item QoItem, Playlist QoPlaylist, string downloadPath, string filePath, int paddedTrackLength, DownloadStats stats, CancellationToken abortToken)
         {
-            var QoStream = QoService.TrackGetFileUrl(QoItem.Id.ToString(), format_id, app_id, user_auth_token, app_secret);
-            string streamURL = QoStream?.StreamURL;
-            if (string.IsNullOrWhiteSpace(streamURL)) {
+            string streamURL = resolvedStream?.Stream?.StreamURL;
+            if (string.IsNullOrWhiteSpace(streamURL))
+            {
                 string msg = $"{qbdlxForm._qbdlxForm.downloadOutputNoUrl.Replace("{TrackNumber}", QoItem.TrackNumber.ToString().PadLeft(paddedTrackLength, '0'))}\r\n";
                 getInfo.updateDownloadOutput(msg);
                 Miscellaneous.LogNotDownloadableTrackEntry(downloadPath, QoItem, msg);
@@ -98,7 +193,7 @@ namespace QobuzDownloaderX
             if (abortToken.IsCancellationRequested) { abortToken.ThrowIfCancellationRequested(); }
 
             // Download stream
-            await downloadFile.DownloadStream(downloadType, streamURL, downloadPath, filePath, audio_format, QoAlbum, QoItem, getInfo, abortToken, stats);
+            await downloadFile.DownloadStream(downloadType, streamURL, downloadPath, filePath, resolvedStream.EffectiveAudioFormat, QoAlbum, QoItem, getInfo, abortToken, stats);
         }
 
         public async Task DownloadTrackAsync(string downloadType, string app_id, string album_id, string format_id, string audio_format, string user_auth_token, string app_secret, string downloadLocation, string artistTemplate, string albumTemplate, string trackTemplate, Album QoAlbum, Item QoItem, IProgress<int> progress, DownloadStats stats, CancellationToken abortToken)
@@ -143,14 +238,52 @@ namespace QobuzDownloaderX
                     try { if (!VerifyStreamable(QoItem, paddedTrackLength)) { progress?.Report(100); return; } }
                     catch (Exception ex) { qbdlxForm._qbdlxForm.logger.Error($"Unable to verify if track is streamable. Error below:\r\n{ex}"); }
 
-                    // Setting up download and file path
-                    downloadPath = await downloadFile.createPath(downloadLocation, artistTemplate, albumTemplate, trackTemplate, null, null, paddedTrackLength, paddedDiscLength, QoAlbum, QoItem, null);
+                    ResolvedStreamSelection resolvedStream = ResolveBestAvailableStream(app_id, format_id, user_auth_token, app_secret, QoItem, audio_format);
+                    if (resolvedStream == null)
+                    {
+                        string msg = $"{qbdlxForm._qbdlxForm.downloadOutputNoUrl.Replace("{TrackNumber}", QoItem.TrackNumber.ToString().PadLeft(paddedTrackLength, '0'))}\r\n";
+                        getInfo.updateDownloadOutput(msg);
+                        Miscellaneous.LogNotDownloadableTrackEntry(downloadLocation, QoItem, msg);
+                        qbdlxForm._qbdlxForm.logger.Error(msg);
+                        progress?.Report(100);
+                        return;
+                    }
 
-                    string trackTemplateConverted = renameTemplates.renameTemplates(trackTemplate, paddedTrackLength, paddedDiscLength, audio_format, QoAlbum, QoItem, null);
+                    string effectiveAudioFormat = resolvedStream.EffectiveAudioFormat ?? audio_format;
+
+                    // Setting up download and file path
+                    downloadPath = await downloadFile.createPath(
+                        downloadLocation,
+                        artistTemplate,
+                        albumTemplate,
+                        trackTemplate,
+                        null,
+                        null,
+                        paddedTrackLength,
+                        paddedDiscLength,
+                        QoAlbum,
+                        QoItem,
+                        null,
+                        downloadType == "track" ? resolvedStream.EffectiveFormatId : null,
+                        downloadType == "track" ? resolvedStream.EffectiveBitDepth : null,
+                        downloadType == "track" ? resolvedStream.EffectiveSamplingRate : null);
+
+                    string trackTemplateConverted = renameTemplates.renameTemplates(
+                        trackTemplate,
+                        paddedTrackLength,
+                        paddedDiscLength,
+                        effectiveAudioFormat,
+                        QoAlbum,
+                        QoItem,
+                        null,
+                        resolvedStream.EffectiveFormatId,
+                        resolvedStream.EffectiveBitDepth,
+                        resolvedStream.EffectiveSamplingRate);
 
                     if (trackTemplateConverted.Contains(@"\"))
                     {
-                        downloadPath = downloadPath + trackTemplateConverted.Substring(0, trackTemplateConverted.LastIndexOf(@"\")) + @"\";
+                        string trackSubDirectory = trackTemplateConverted.Substring(0, trackTemplateConverted.LastIndexOf(@"\"));
+                        downloadPath = SecurityHelpers.EnsureTrailingDirectorySeparator(SecurityHelpers.EnsurePathIsWithinRoot(downloadLocation, Path.Combine(downloadPath, trackSubDirectory), nameof(downloadPath)));
                         trackTemplateConverted = trackTemplateConverted.Substring(trackTemplateConverted.LastIndexOf(@"\") + 1);
                         Debug.WriteLine(downloadPath);
                     }
@@ -159,14 +292,15 @@ namespace QobuzDownloaderX
                     if (!(downloadType == "track") && QoAlbum.MediaCount > 1 && (!string.IsNullOrWhiteSpace(Settings.Default.savedCdTemplate)))
                     {
                         string cdDirectoryName = qbdlxForm.discNumberRegex.Replace(Settings.Default.savedCdTemplate, QoItem.MediaNumber.ToString());
-                        filePath = downloadPath + cdDirectoryName + ZlpPathHelper.DirectorySeparatorChar + trackTemplateConverted.TrimEnd() + audio_format;
+                        filePath = Path.Combine(downloadPath, cdDirectoryName, trackTemplateConverted.TrimEnd() + effectiveAudioFormat);
                         // Previous, original logic:
                         // filePath = downloadPath + "CD " + QoItem.MediaNumber.ToString().PadLeft(paddedDiscLength, '0') + ZlpPathHelper.DirectorySeparatorChar + trackTemplateConverted.TrimEnd() + audio_format;
                     }
                     else
                     {
-                        filePath = downloadPath + trackTemplateConverted.TrimEnd() + audio_format;
+                        filePath = Path.Combine(downloadPath, trackTemplateConverted.TrimEnd() + effectiveAudioFormat);
                     }
+                    filePath = SecurityHelpers.EnsurePathIsWithinRoot(downloadLocation, filePath, nameof(filePath));
 
                     if (qbdlxForm.duplicateFileMode == DuplicateFileMode.SkipDownloads)
                     {
@@ -182,7 +316,7 @@ namespace QobuzDownloaderX
                     try { await downloadFile.DownloadArtwork(downloadPath, QoAlbum); } catch (Exception ex) { qbdlxForm._qbdlxForm.logger.Error($"Failed to Download Cover Art. Error below:\r\n{ex}"); }
 
                     // Download and Save Track
-                    await DownloadAndSaveTrack(downloadType, app_id, format_id, user_auth_token, app_secret, QoAlbum, QoItem, null, downloadPath, filePath, audio_format, paddedTrackLength, stats, abortToken);
+                    await DownloadAndSaveTrack(downloadType, resolvedStream, QoAlbum, QoItem, null, downloadPath, filePath, paddedTrackLength, stats, abortToken);
 
                     if (abortToken.IsCancellationRequested) { abortToken.ThrowIfCancellationRequested(); }
                     progress?.Report(100);
@@ -203,7 +337,8 @@ namespace QobuzDownloaderX
                 }
                 finally
                 {
-                    if (!(downloadType == "album")){
+                    if (!(downloadType == "album"))
+                    {
                         // Delete image used for embedded artwork
                         Miscellaneous.DeleteTempEmbeddedArtwork();
                     }
@@ -228,19 +363,43 @@ namespace QobuzDownloaderX
 
                 try
                 {
+                    ResolvedStreamSelection resolvedStream = ResolveBestAvailableStream(app_id, format_id, user_auth_token, app_secret, QoItem, audio_format);
+                    if (resolvedStream == null)
+                    {
+                        string msg = $"{qbdlxForm._qbdlxForm.downloadOutputNoUrl.Replace("{TrackNumber}", QoItem.TrackNumber.ToString().PadLeft(paddedTrackLength, '0'))}\r\n";
+                        getInfo.updateDownloadOutput(msg);
+                        Miscellaneous.LogNotDownloadableTrackEntry(downloadLocation, QoItem, msg);
+                        qbdlxForm._qbdlxForm.logger.Error(msg);
+                        progress?.Report(100);
+                        return;
+                    }
+
+                    string effectiveAudioFormat = resolvedStream.EffectiveAudioFormat ?? audio_format;
+
                     // Setting up download and file path
                     downloadPath = await downloadFile.createPath(downloadLocation, null, null, trackTemplate, playlistTemplate, null, paddedTrackLength, paddedDiscLength, QoAlbum, QoItem, QoPlaylist);
-                    string trackTemplateConverted = renameTemplates.renameTemplates(trackTemplate, paddedTrackLength, paddedDiscLength, audio_format, QoAlbum, QoItem, QoPlaylist);
+                    string trackTemplateConverted = renameTemplates.renameTemplates(
+                        trackTemplate,
+                        paddedTrackLength,
+                        paddedDiscLength,
+                        effectiveAudioFormat,
+                        QoAlbum,
+                        QoItem,
+                        QoPlaylist,
+                        resolvedStream.EffectiveFormatId,
+                        resolvedStream.EffectiveBitDepth,
+                        resolvedStream.EffectiveSamplingRate);
 
                     if (trackTemplateConverted.Contains(@"\"))
                     {
-                        downloadPath = downloadPath + trackTemplateConverted.Substring(0, trackTemplateConverted.LastIndexOf(@"\")) + @"\";
+                        string trackSubDirectory = trackTemplateConverted.Substring(0, trackTemplateConverted.LastIndexOf(@"\"));
+                        downloadPath = SecurityHelpers.EnsureTrailingDirectorySeparator(SecurityHelpers.EnsurePathIsWithinRoot(downloadLocation, Path.Combine(downloadPath, trackSubDirectory), nameof(downloadPath)));
                         trackTemplateConverted = trackTemplateConverted.Substring(trackTemplateConverted.LastIndexOf(@"\") + 1);
                         Debug.WriteLine(downloadPath);
                     }
 
-                    filePath = downloadPath + trackTemplateConverted.TrimEnd() + audio_format;
-
+                    filePath = Path.Combine(downloadPath, trackTemplateConverted.TrimEnd() + effectiveAudioFormat);
+                    filePath = SecurityHelpers.EnsurePathIsWithinRoot(downloadLocation, filePath, nameof(filePath));
 
                     if (qbdlxForm.duplicateFileMode == DuplicateFileMode.SkipDownloads)
                     {
@@ -260,7 +419,7 @@ namespace QobuzDownloaderX
                     catch { }
 
                     // Download and Save Track
-                    await DownloadAndSaveTrack(downloadType, app_id, format_id, user_auth_token, app_secret, QoAlbum, QoItem, QoPlaylist, downloadPath, filePath, audio_format, paddedTrackLength, stats, abortToken);
+                    await DownloadAndSaveTrack(downloadType, resolvedStream, QoAlbum, QoItem, QoPlaylist, downloadPath, filePath, paddedTrackLength, stats, abortToken);
 
                     // Delete image used for embedded artwork
                     CleanupArtwork();

--- a/QobuzDownloaderX/Helpers/Download/DownloadTrack.cs
+++ b/QobuzDownloaderX/Helpers/Download/DownloadTrack.cs
@@ -169,7 +169,7 @@ namespace QobuzDownloaderX
             }
         }
 
-        private async Task DownloadAndSaveTrack(string downloadType, ResolvedStreamSelection resolvedStream, Album QoAlbum, Item QoItem, Playlist QoPlaylist, string downloadPath, string filePath, int paddedTrackLength, DownloadStats stats, CancellationToken abortToken)
+        private async Task<bool> DownloadAndSaveTrack(string downloadType, ResolvedStreamSelection resolvedStream, Album QoAlbum, Item QoItem, Playlist QoPlaylist, string downloadPath, string filePath, int paddedTrackLength, DownloadStats stats, CancellationToken abortToken)
         {
             string streamURL = resolvedStream?.Stream?.StreamURL;
             if (string.IsNullOrWhiteSpace(streamURL))
@@ -178,7 +178,7 @@ namespace QobuzDownloaderX
                 getInfo.updateDownloadOutput(msg);
                 Miscellaneous.LogNotDownloadableTrackEntry(downloadPath, QoItem, msg);
                 qbdlxForm._qbdlxForm.logger.Error(msg);
-                return;
+                return false;
             }
 
             // Display download status (depending on track number or playlist position number)
@@ -193,10 +193,10 @@ namespace QobuzDownloaderX
             if (abortToken.IsCancellationRequested) { abortToken.ThrowIfCancellationRequested(); }
 
             // Download stream
-            await downloadFile.DownloadStream(downloadType, streamURL, downloadPath, filePath, resolvedStream.EffectiveAudioFormat, QoAlbum, QoItem, getInfo, abortToken, stats);
+            return await downloadFile.DownloadStream(downloadType, streamURL, downloadPath, filePath, resolvedStream.EffectiveAudioFormat, QoAlbum, QoItem, getInfo, abortToken, stats);
         }
 
-        public async Task DownloadTrackAsync(string downloadType, string app_id, string album_id, string format_id, string audio_format, string user_auth_token, string app_secret, string downloadLocation, string artistTemplate, string albumTemplate, string trackTemplate, Album QoAlbum, Item QoItem, IProgress<int> progress, DownloadStats stats, CancellationToken abortToken)
+        public async Task<bool> DownloadTrackAsync(string downloadType, string app_id, string album_id, string format_id, string audio_format, string user_auth_token, string app_secret, string downloadLocation, string artistTemplate, string albumTemplate, string trackTemplate, Album QoAlbum, Item QoItem, IProgress<int> progress, DownloadStats stats, CancellationToken abortToken)
         {
             // Empty output on main form if individual track download
             if (downloadType == "track") { getInfo.outputText = null; }
@@ -231,11 +231,11 @@ namespace QobuzDownloaderX
                         Miscellaneous.LogNotStreamableAlbumEntry(directoryPath, QoAlbum, msg);
 
                         progress?.Report(100);
-                        return;
+                        return false;
                     }
 
                     // Verify Streamable
-                    try { if (!VerifyStreamable(QoItem, paddedTrackLength)) { progress?.Report(100); return; } }
+                    try { if (!VerifyStreamable(QoItem, paddedTrackLength)) { progress?.Report(100); return false; } }
                     catch (Exception ex) { qbdlxForm._qbdlxForm.logger.Error($"Unable to verify if track is streamable. Error below:\r\n{ex}"); }
 
                     ResolvedStreamSelection resolvedStream = ResolveBestAvailableStream(app_id, format_id, user_auth_token, app_secret, QoItem, audio_format);
@@ -246,27 +246,28 @@ namespace QobuzDownloaderX
                         Miscellaneous.LogNotDownloadableTrackEntry(downloadLocation, QoItem, msg);
                         qbdlxForm._qbdlxForm.logger.Error(msg);
                         progress?.Report(100);
-                        return;
+                        return false;
                     }
 
                     string effectiveAudioFormat = resolvedStream.EffectiveAudioFormat ?? audio_format;
 
                     // Setting up download and file path
                     downloadPath = await downloadFile.createPath(
-                        downloadLocation,
-                        artistTemplate,
-                        albumTemplate,
-                        trackTemplate,
-                        null,
-                        null,
-                        paddedTrackLength,
-                        paddedDiscLength,
-                        QoAlbum,
-                        QoItem,
-                        null,
-                        downloadType == "track" ? resolvedStream.EffectiveFormatId : null,
-                        downloadType == "track" ? resolvedStream.EffectiveBitDepth : null,
-                        downloadType == "track" ? resolvedStream.EffectiveSamplingRate : null);
+                            downloadLocation,
+                            artistTemplate,
+                            albumTemplate,
+                            trackTemplate,
+                            null,
+                            null,
+                            paddedTrackLength,
+                            paddedDiscLength,
+                            QoAlbum,
+                            QoItem,
+                            null,
+                            effectiveAudioFormat,
+                            downloadType == "track" ? resolvedStream.EffectiveFormatId : null,
+                            downloadType == "track" ? resolvedStream.EffectiveBitDepth : null,
+                            downloadType == "track" ? resolvedStream.EffectiveSamplingRate : null);
 
                     string trackTemplateConverted = renameTemplates.renameTemplates(
                         trackTemplate,
@@ -308,7 +309,7 @@ namespace QobuzDownloaderX
                         if (CheckForExistingFile(filePath, paddedTrackLength, QoItem))
                         {
                             progress?.Report(100);
-                            return;
+                            return true;
                         }
                     }
 
@@ -316,24 +317,27 @@ namespace QobuzDownloaderX
                     try { await downloadFile.DownloadArtwork(downloadPath, QoAlbum); } catch (Exception ex) { qbdlxForm._qbdlxForm.logger.Error($"Failed to Download Cover Art. Error below:\r\n{ex}"); }
 
                     // Download and Save Track
-                    await DownloadAndSaveTrack(downloadType, resolvedStream, QoAlbum, QoItem, null, downloadPath, filePath, paddedTrackLength, stats, abortToken);
+                    bool downloadSucceeded = await DownloadAndSaveTrack(downloadType, resolvedStream, QoAlbum, QoItem, null, downloadPath, filePath, paddedTrackLength, stats, abortToken);
+                    if (!downloadSucceeded)
+                    {
+                        progress?.Report(100);
+                        return false;
+                    }
 
                     if (abortToken.IsCancellationRequested) { abortToken.ThrowIfCancellationRequested(); }
                     progress?.Report(100);
+                    return true;
                 }
                 catch (OperationCanceledException ex)
                 {
-                    if (!abortToken.IsCancellationRequested)
-                    {
-                        qbdlxForm._qbdlxForm.logger.Error("Download canceled: " + ex.Message);
-                        throw;
-                    }
+                    qbdlxForm._qbdlxForm.logger.Error("Download canceled: " + ex.Message);
+                    throw;
                 }
                 catch (Exception downloadAlbumEx)
                 {
                     getInfo.updateDownloadOutput("\r\n\r\n" + downloadAlbumEx + "\r\n\r\n");
                     Debug.WriteLine(downloadAlbumEx);
-                    return;
+                    return false;
                 }
                 finally
                 {
@@ -344,14 +348,18 @@ namespace QobuzDownloaderX
                     }
                 }
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception downloadAlbumEx)
             {
                 Debug.WriteLine(downloadAlbumEx);
-                return;
+                return false;
             }
         }
 
-        public async Task DownloadPlaylistTrackAsync(string downloadType, string app_id, string format_id, string audio_format, string user_auth_token, string app_secret, string downloadLocation, string trackTemplate, string playlistTemplate, Album QoAlbum, Item QoItem, Playlist QoPlaylist, IProgress<int> progress, DownloadStats stats, CancellationToken abortToken)
+        public async Task<bool> DownloadPlaylistTrackAsync(string downloadType, string app_id, string format_id, string audio_format, string user_auth_token, string app_secret, string downloadLocation, string trackTemplate, string playlistTemplate, Album QoAlbum, Item QoItem, Playlist QoPlaylist, IProgress<int> progress, DownloadStats stats, CancellationToken abortToken)
         {
             try
             {
@@ -359,7 +367,7 @@ namespace QobuzDownloaderX
                 CreatePadding(null, QoPlaylist);
 
                 // Verify Streamable
-                if (!VerifyStreamable(QoItem, paddedTrackLength)) return;
+                if (!VerifyStreamable(QoItem, paddedTrackLength)) return false;
 
                 try
                 {
@@ -371,13 +379,28 @@ namespace QobuzDownloaderX
                         Miscellaneous.LogNotDownloadableTrackEntry(downloadLocation, QoItem, msg);
                         qbdlxForm._qbdlxForm.logger.Error(msg);
                         progress?.Report(100);
-                        return;
+                        return false;
                     }
 
                     string effectiveAudioFormat = resolvedStream.EffectiveAudioFormat ?? audio_format;
 
                     // Setting up download and file path
-                    downloadPath = await downloadFile.createPath(downloadLocation, null, null, trackTemplate, playlistTemplate, null, paddedTrackLength, paddedDiscLength, QoAlbum, QoItem, QoPlaylist);
+                    downloadPath = await downloadFile.createPath(
+                        downloadLocation,
+                        null,
+                        null,
+                        trackTemplate,
+                        playlistTemplate,
+                        null,
+                        paddedTrackLength,
+                        paddedDiscLength,
+                        QoAlbum,
+                        QoItem,
+                        QoPlaylist,
+                        effectiveAudioFormat,
+                        resolvedStream.EffectiveFormatId,
+                        resolvedStream.EffectiveBitDepth,
+                        resolvedStream.EffectiveSamplingRate);
                     string trackTemplateConverted = renameTemplates.renameTemplates(
                         trackTemplate,
                         paddedTrackLength,
@@ -407,7 +430,7 @@ namespace QobuzDownloaderX
                         if (CheckForExistingFile(filePath, paddedTrackLength, QoItem))
                         {
                             progress?.Report(100);
-                            return;
+                            return true;
                         }
                     }
 
@@ -419,32 +442,41 @@ namespace QobuzDownloaderX
                     catch { }
 
                     // Download and Save Track
-                    await DownloadAndSaveTrack(downloadType, resolvedStream, QoAlbum, QoItem, QoPlaylist, downloadPath, filePath, paddedTrackLength, stats, abortToken);
+                    bool downloadSucceeded = await DownloadAndSaveTrack(downloadType, resolvedStream, QoAlbum, QoItem, QoPlaylist, downloadPath, filePath, paddedTrackLength, stats, abortToken);
+                    if (!downloadSucceeded)
+                    {
+                        CleanupArtwork();
+                        progress?.Report(100);
+                        return false;
+                    }
 
                     // Delete image used for embedded artwork
                     CleanupArtwork();
                     progress?.Report(100);
+                    return true;
                 }
                 catch (OperationCanceledException ex)
                 {
-                    if (!abortToken.IsCancellationRequested)
-                    {
-                        qbdlxForm._qbdlxForm.logger.Error("Download canceled: " + ex.Message);
-                        throw;
-                    }
+                    qbdlxForm._qbdlxForm.logger.Error("Download canceled: " + ex.Message);
+                    throw;
                 }
                 catch (Exception downloadAlbumEx)
                 {
                     getInfo.updateDownloadOutput("\r\n\r\n" + downloadAlbumEx + "\r\n\r\n");
                     Debug.WriteLine(downloadAlbumEx);
-                    return;
+                    CleanupArtwork();
+                    return false;
                 }
 
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
             }
             catch (Exception downloadAlbumEx)
             {
                 Debug.WriteLine(downloadAlbumEx);
-                return;
+                return false;
             }
         }
     }

--- a/QobuzDownloaderX/Helpers/FixMD5.cs
+++ b/QobuzDownloaderX/Helpers/FixMD5.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Diagnostics;
+using System.IO;
 
 namespace QobuzDownloaderX.Helpers
 {
@@ -12,19 +13,33 @@ namespace QobuzDownloaderX.Helpers
         public void fixMD5(string filePath, string flacEXEPath)
         {
             qbdlxForm._qbdlxForm.logger.Debug("Attempting to fix unset MD5…");
-            // string driveLetter = filePath.Substring(0, 2); // UNUSED
-            string cmdText = "/C echo Fixing unset MD5s... & \"" + flacEXEPath + "\" -f8 \"" + filePath + "\"";
-            qbdlxForm._qbdlxForm.logger.Debug("Commands - " + cmdText);
 
             try
             {
-                qbdlxForm._qbdlxForm.logger.Debug("Running CMD command to fix MD5…");
-                Process cmd = new Process();
-                cmd.StartInfo.FileName = "cmd.exe";
-                cmd.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
-                cmd.StartInfo.Arguments = cmdText;
-                cmd.Start();
-                cmd.WaitForExit();
+                string flacExecutablePath = SecurityHelpers.ResolveExecutablePath(flacEXEPath);
+                qbdlxForm._qbdlxForm.logger.Debug("Running FLAC command directly to fix MD5…");
+
+                using (Process cmd = new Process())
+                {
+                    cmd.StartInfo = new ProcessStartInfo
+                    {
+                        FileName = flacExecutablePath,
+                        Arguments = $"-f8 \"{filePath}\"",
+                        CreateNoWindow = true,
+                        UseShellExecute = false,
+                        WindowStyle = ProcessWindowStyle.Hidden,
+                        WorkingDirectory = Path.GetDirectoryName(flacExecutablePath)
+                    };
+
+                    cmd.Start();
+                    cmd.WaitForExit();
+
+                    if (cmd.ExitCode != 0)
+                    {
+                        throw new InvalidOperationException($"flac exited with code {cmd.ExitCode}.");
+                    }
+                }
+
                 outputResult = "COMPLETE";
                 qbdlxForm._qbdlxForm.logger.Debug("MD5 has been fixed for file!");
             }

--- a/QobuzDownloaderX/Helpers/FlexibleSettingsProvider.cs
+++ b/QobuzDownloaderX/Helpers/FlexibleSettingsProvider.cs
@@ -18,6 +18,7 @@ using System.Security.Principal;
 using System.Text;
 using System.Xml.Linq;
 using System.Diagnostics;
+using QobuzDownloaderX.Helpers;
 
 /// <summary>
 /// A settings provider that stores application settings in a configurable directory and filename.
@@ -90,7 +91,7 @@ public class FlexibleSettingsProvider : SettingsProvider
     /// <summary>
     /// Gets the fully qualified configuration file path (directory + filename).
     /// </summary>
-    public string ConfigFileFullName => Path.Combine(ConfigDirectoryPath, ConfigFileName);
+    public string ConfigFileFullName => Path.Combine(GetPreferredConfigDirectory(), ConfigFileName);
 
     #endregion
 
@@ -146,13 +147,7 @@ public class FlexibleSettingsProvider : SettingsProvider
     {
         var values = new SettingsPropertyValueCollection();
         XDocument doc = null;
-        string configPath = ConfigFileFullName;
-
-        // If ConfigDirectoryPath is ".", combine with current directory explicitly.
-        if (ConfigDirectoryPath == ".")
-        {
-            configPath = Path.Combine(Directory.GetCurrentDirectory(), ConfigFileName);
-        }
+        string configPath = GetExistingConfigPath();
 
         if (File.Exists(configPath))
         {
@@ -200,9 +195,7 @@ public class FlexibleSettingsProvider : SettingsProvider
     /// <param name="values">Collection of Setting values to persist.</param>
     public override void SetPropertyValues(SettingsContext context, SettingsPropertyValueCollection values)
     {
-        EnsureConfigDirectory();
-
-        string targetDirectory = ConfigDirectoryPath == "." ? Directory.GetCurrentDirectory() : ConfigDirectoryPath;
+        string targetDirectory = EnsureConfigDirectory();
         string targetPath = Path.Combine(targetDirectory, ConfigFileName);
 
         var root = new XElement("settings");
@@ -395,9 +388,9 @@ public class FlexibleSettingsProvider : SettingsProvider
     /// If the configured directory fails, falls back to LocalApplicationData.
     /// Throws InvalidOperationException when no writable directory can be found.
     /// </summary>
-    private void EnsureConfigDirectory()
+    private string EnsureConfigDirectory()
     {
-        string tempConfigDirectoryPath = ConfigDirectoryPath == "." ? Directory.GetCurrentDirectory() : ConfigDirectoryPath;
+        string tempConfigDirectoryPath = GetPreferredConfigDirectory();
 
         if (string.IsNullOrWhiteSpace(tempConfigDirectoryPath))
         {
@@ -424,12 +417,49 @@ public class FlexibleSettingsProvider : SettingsProvider
 
         if (!CanWriteToDirectory(tempConfigDirectoryPath))
         {
-            if (tempConfigDirectoryPath != ConfigDirectoryPathFallback)
+            if (!tempConfigDirectoryPath.Equals(ConfigDirectoryPathFallback, StringComparison.OrdinalIgnoreCase))
+            {
                 tempConfigDirectoryPath = ConfigDirectoryPathFallback;
+                Directory.CreateDirectory(tempConfigDirectoryPath);
+            }
 
             if (!CanWriteToDirectory(tempConfigDirectoryPath))
                 throw new InvalidOperationException($"Cannot write application's configuration file in directory: {tempConfigDirectoryPath}. Check user permissions.");
         }
+
+        return tempConfigDirectoryPath;
+    }
+
+    private string GetPreferredConfigDirectory()
+    {
+        string configuredDirectory = ConfigDirectoryPath?.Trim();
+
+        if (string.IsNullOrWhiteSpace(configuredDirectory)
+            || configuredDirectory == "."
+            || configuredDirectory == @".\"
+            || configuredDirectory == "./")
+        {
+            return ConfigDirectoryPathFallback;
+        }
+
+        return configuredDirectory;
+    }
+
+    private string GetExistingConfigPath()
+    {
+        string primaryPath = Path.Combine(GetPreferredConfigDirectory(), ConfigFileName);
+        if (File.Exists(primaryPath))
+        {
+            return primaryPath;
+        }
+
+        string legacyPath = Path.Combine(Directory.GetCurrentDirectory(), ConfigFileName);
+        if (!primaryPath.Equals(legacyPath, StringComparison.OrdinalIgnoreCase) && File.Exists(legacyPath))
+        {
+            return legacyPath;
+        }
+
+        return primaryPath;
     }
 
     #endregion

--- a/QobuzDownloaderX/Helpers/GetInfo.cs
+++ b/QobuzDownloaderX/Helpers/GetInfo.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace QobuzDownloaderX.Helpers
 {
@@ -17,6 +18,16 @@ namespace QobuzDownloaderX.Helpers
         public QopenAPI.Label QoLabel = new QopenAPI.Label();
 
         public string outputText { get; set; }
+        public CancellationToken UiCancellationToken { get; set; } = CancellationToken.None;
+
+        private bool CanUpdateUi()
+        {
+            return !UiCancellationToken.IsCancellationRequested
+                && qbdlxForm._qbdlxForm != null
+                && !qbdlxForm._qbdlxForm.IsDisposed
+                && qbdlxForm._qbdlxForm.downloadOutput != null
+                && !qbdlxForm._qbdlxForm.downloadOutput.IsDisposed;
+        }
 
         public HashSet<string> GetArtistReleaseTypeIds(string app_id, string artist_id, string selectedTypes, string user_auth_token)
         {
@@ -445,7 +456,12 @@ namespace QobuzDownloaderX.Helpers
 
         public void updateDownloadOutput(string text)
         {
-            if (outputText == "Test String" | outputText == null)
+            if (!CanUpdateUi())
+            {
+                return;
+            }
+
+            if (outputText == "Test String" || outputText == null)
             {
                 Miscellaneous.update(qbdlxForm._qbdlxForm, null);
                 outputText = qbdlxForm._qbdlxForm.downloadOutput.Text;

--- a/QobuzDownloaderX/Helpers/Miscellaneous.cs
+++ b/QobuzDownloaderX/Helpers/Miscellaneous.cs
@@ -24,9 +24,7 @@ namespace QobuzDownloaderX.Helpers
         [DebuggerStepThrough]
         internal static void SetTLSSetting()
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls
-                                                 | SecurityProtocolType.Tls11
-                                                 | SecurityProtocolType.Tls12;
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
             if (Settings.Default.useTLS13)
             {
@@ -384,7 +382,7 @@ namespace QobuzDownloaderX.Helpers
         {
             // Set saved language
             f.languageManager = new LanguageManager();
-            f.languageManager.LoadLanguage($"languages/{Settings.Default.currentLanguage.ToLower()}.json");
+            f.languageManager.LoadLanguage(Path.Combine(f.languageManager.languagesDirectory, Settings.Default.currentLanguage.ToLower() + ".json"));
 
             // Populate theme options in settings
             f.languageManager.PopulateLanguageComboBox(f);

--- a/QobuzDownloaderX/Helpers/Miscellaneous.cs
+++ b/QobuzDownloaderX/Helpers/Miscellaneous.cs
@@ -1128,7 +1128,24 @@ namespace QobuzDownloaderX.Helpers
             return result;
         }
 
-        private static async Task RunTaskWithTimeoutAsync(qbdlxForm form, Task workTask, TimeSpan timeout, string timeoutMessage = "Task has timed out.")
+        private static void TryCancelUiUpdates(CancellationTokenSource staleUiUpdatesCts)
+        {
+            if (staleUiUpdatesCts == null)
+            {
+                return;
+            }
+
+            try
+            {
+                staleUiUpdatesCts.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // The worker already completed and disposed its CTS.
+            }
+        }
+
+        private static async Task RunTaskWithTimeoutAsync(qbdlxForm form, Task workTask, TimeSpan timeout, string timeoutMessage = "Task has timed out.", CancellationTokenSource staleUiUpdatesCts = null)
         {
             if (form == null)
                 throw new ArgumentNullException(nameof(form));
@@ -1153,23 +1170,49 @@ namespace QobuzDownloaderX.Helpers
                 else
                 {
                     // Timeout reached
+                    TryCancelUiUpdates(staleUiUpdatesCts);
                     form.Invoke((MethodInvoker)(() =>
                     {
                         form.downloadOutput.Text += $"\r\n[Timeout {timeout.TotalSeconds:F1}s] {timeoutMessage}";
                     }));
-                    // Note: the background task keeps running, but we continue execution here.
-                    throw new OperationCanceledException();
+                    throw new TimeoutException(timeoutMessage);
                 }
+            }
+            catch (TimeoutException)
+            {
+                throw;
             }
             catch (Exception ex)
             {
                 // Any exception from the work action.
+                TryCancelUiUpdates(staleUiUpdatesCts);
                 form.Invoke((MethodInvoker)(() =>
                 {
                     form.downloadOutput.Text += $"\r\nError: {ex.Message}";
                 }));
                 throw;
             }
+        }
+
+        private static async Task<GetInfo> ExecuteGetInfoTaskWithTimeoutAsync(qbdlxForm form, Action<GetInfo> workAction, TimeSpan timeout, string timeoutMessage)
+        {
+            if (form == null)
+                throw new ArgumentNullException(nameof(form));
+
+            if (workAction == null)
+                throw new ArgumentNullException(nameof(workAction));
+
+            var scopedUiUpdatesCts = new CancellationTokenSource();
+            var scopedGetInfo = new GetInfo
+            {
+                UiCancellationToken = scopedUiUpdatesCts.Token
+            };
+
+            var workTask = Task.Run(() => workAction(scopedGetInfo));
+            _ = workTask.ContinueWith(_ => scopedUiUpdatesCts.Dispose(), TaskScheduler.Default);
+
+            await RunTaskWithTimeoutAsync(form, workTask, timeout, timeoutMessage, scopedUiUpdatesCts);
+            return scopedGetInfo;
         }
 
         internal static async Task downloadButtonAsyncWork(qbdlxForm f, DownloadStats stats = null)
@@ -1377,14 +1420,18 @@ namespace QobuzDownloaderX.Helpers
                     if (!qbdlxForm.isBatchDownloadRunning) TaskbarHelper.SetProgressValue(0, f.progressBarDownload.Maximum);
 
                     // [FETCH INFO] case "album" -> getAlbumInfoLabels
-                    var albumTask = Task.Run(() => f.getInfo.getAlbumInfoLabels(f.app_id, f.qobuz_id, f.user_auth_token));
+                    GetInfo albumGetInfo;
                     try
                     {
-                        await RunTaskWithTimeoutAsync(f, albumTask, getInfosTimeOut, "Q(Open)API 'getAlbumInfoLabels' task has timed out.");
+                        albumGetInfo = await ExecuteGetInfoTaskWithTimeoutAsync(
+                            f,
+                            getInfo => getInfo.getAlbumInfoLabels(f.app_id, f.qobuz_id, f.user_auth_token),
+                            getInfosTimeOut,
+                            "Q(Open)API 'getAlbumInfoLabels' task has timed out.");
                     }
                     catch { return; }
 
-                    f.QoAlbum = f.getInfo.QoAlbum;
+                    f.QoAlbum = albumGetInfo.QoAlbum;
                     if (f.QoAlbum == null)
                     {
                         f.getInfo.updateDownloadOutput($"{f.downloadOutputAPIError}");
@@ -1409,12 +1456,19 @@ namespace QobuzDownloaderX.Helpers
                     });
 
                     // [DOWNLOAD] case "album" -> DownloadAlbumAsync
-                    await Task.Run(() => f.downloadAlbum.DownloadAlbumAsync(f.app_id, f.qobuz_id, f.format_id, f.audio_format, f.user_auth_token, f.app_secret, f.downloadLocation, f.artistTemplate, f.albumTemplate, f.trackTemplate, f.QoAlbum, progress, albumTrackCounter, stats, abortToken));
+                    bool albumSucceeded = await Task.Run(() => f.downloadAlbum.DownloadAlbumAsync(f.app_id, f.qobuz_id, f.format_id, f.audio_format, f.user_auth_token, f.app_secret, f.downloadLocation, f.artistTemplate, f.albumTemplate, f.trackTemplate, f.QoAlbum, progress, albumTrackCounter, stats, abortToken));
                     if (abortToken.IsCancellationRequested) { abortToken.ThrowIfCancellationRequested(); }
                   
-                    // Say the downloading is finished when it's completed.
-                    f.getInfo.outputText = qbdlxForm._qbdlxForm.downloadOutput.Text;
-                    f.getInfo.updateDownloadOutput("\r\n" + f.downloadOutputCompleted);
+                    if (albumSucceeded)
+                    {
+                        // Say the downloading is finished when it's completed.
+                        f.getInfo.outputText = qbdlxForm._qbdlxForm.downloadOutput.Text;
+                        f.getInfo.updateDownloadOutput("\r\n" + f.downloadOutputCompleted);
+                    }
+                    else if (!qbdlxForm.isBatchDownloadRunning)
+                    {
+                        TaskbarHelper.SetProgressState(TaskbarProgressState.Error);
+                    }
                     f.progressLabel.Invoke(new Action(() => f.progressLabel.Text = f.progressLabelInactive));
                     break;
 
@@ -1423,27 +1477,41 @@ namespace QobuzDownloaderX.Helpers
                     if (!qbdlxForm.isBatchDownloadRunning) TaskbarHelper.SetProgressValue(0, f.progressBarDownload.Maximum);
 
                     // [FETCH INFO] case "track" -> getTrackInfoLabels
-                    var trackTask = Task.Run(() => f.getInfo.getTrackInfoLabels(f.app_id, f.qobuz_id, f.user_auth_token));
+                    GetInfo trackGetInfo;
                     try
                     {
-                        await RunTaskWithTimeoutAsync(f, trackTask, getInfosTimeOut, "Q(Open)API 'getTrackInfoLabels' task has timed out.");
+                        trackGetInfo = await ExecuteGetInfoTaskWithTimeoutAsync(
+                            f,
+                            getInfo => getInfo.getTrackInfoLabels(f.app_id, f.qobuz_id, f.user_auth_token),
+                            getInfosTimeOut,
+                            "Q(Open)API 'getTrackInfoLabels' task has timed out.");
                     }
                     catch { return; }
                    
-                    f.QoItem = f.getInfo.QoItem;
-                    f.QoAlbum = f.getInfo.QoAlbum;
+                    f.QoItem = trackGetInfo.QoItem;
+                    f.QoAlbum = trackGetInfo.QoAlbum;
                     updateAlbumInfoLabels(f, f.QoAlbum);
                     f.progressItemsCountLabel.Text = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(f.languageManager.GetTranslation("track"));
 
                     // [DOWNLOAD] case "track" -> DownloadTrackAsync
-                    await Task.Run(() => f.downloadTrack.DownloadTrackAsync("track", f.app_id, f.qobuz_id, f.format_id, f.audio_format, f.user_auth_token, f.app_secret, f.downloadLocation, f.artistTemplate, f.albumTemplate, f.trackTemplate, f.QoAlbum, f.QoItem, progress, stats, abortToken));
+                    bool trackSucceeded = await Task.Run(() => f.downloadTrack.DownloadTrackAsync("track", f.app_id, f.qobuz_id, f.format_id, f.audio_format, f.user_auth_token, f.app_secret, f.downloadLocation, f.artistTemplate, f.albumTemplate, f.trackTemplate, f.QoAlbum, f.QoItem, progress, stats, abortToken));
                    
-                    // Say the downloading is finished when it's completed.
-                    if (!qbdlxForm.isBatchDownloadRunning) TaskbarHelper.SetProgressValue(f.progressBarDownload.Maximum, f.progressBarDownload.Maximum);
-                    f.getInfo.outputText = qbdlxForm._qbdlxForm.downloadOutput.Text;
-                    f.getInfo.updateDownloadOutput("\r\n" + f.downloadOutputCompleted);
+                    if (trackSucceeded)
+                    {
+                        // Say the downloading is finished when it's completed.
+                        if (!qbdlxForm.isBatchDownloadRunning) TaskbarHelper.SetProgressValue(f.progressBarDownload.Maximum, f.progressBarDownload.Maximum);
+                        f.getInfo.outputText = qbdlxForm._qbdlxForm.downloadOutput.Text;
+                        f.getInfo.updateDownloadOutput("\r\n" + f.downloadOutputCompleted);
+                    }
+                    else if (!qbdlxForm.isBatchDownloadRunning)
+                    {
+                        TaskbarHelper.SetProgressState(TaskbarProgressState.Error);
+                    }
                     f.progressLabel.Invoke(new Action(() => f.progressLabel.Text = f.progressLabelInactive));
-                    f.progressBarDownload.Invoke(new Action(() => f.progressBarDownload.Value = f.progressBarDownload.Maximum));
+                    if (trackSucceeded)
+                    {
+                        f.progressBarDownload.Invoke(new Action(() => f.progressBarDownload.Value = f.progressBarDownload.Maximum));
+                    }
                     break;
 
                 case "playlist":
@@ -1452,17 +1520,22 @@ namespace QobuzDownloaderX.Helpers
                     if (!qbdlxForm.isBatchDownloadRunning) TaskbarHelper.SetProgressValue(0, f.progressBarDownload.Maximum);
 
                     // [FETCH INFO] case "playlist" -> getPlaylistInfoLabels
-                    var playlistTask = Task.Run(() => f.getInfo.getPlaylistInfoLabels(f.app_id, f.qobuz_id, f.user_auth_token));
+                    GetInfo playlistGetInfo;
                     try
                     {
-                        await RunTaskWithTimeoutAsync(f, playlistTask, getInfosTimeOut, "Q(Open)API 'getPlaylistInfoLabels' task has timed out.");
+                        playlistGetInfo = await ExecuteGetInfoTaskWithTimeoutAsync(
+                            f,
+                            getInfo => getInfo.getPlaylistInfoLabels(f.app_id, f.qobuz_id, f.user_auth_token),
+                            getInfosTimeOut,
+                            "Q(Open)API 'getPlaylistInfoLabels' task has timed out.");
                     }
                     catch { return; }
                   
-                    f.QoPlaylist = f.getInfo.QoPlaylist;
+                    f.QoPlaylist = playlistGetInfo.QoPlaylist;
                     Miscellaneous.updatePlaylistInfoLabels(f, f.QoPlaylist);
                     int totalTracksPlaylist = f.QoPlaylist.Tracks.Items.Count;
                     int trackIndexPlaylist = 0;
+                    bool playlistSucceeded = true;
                     foreach (var item in f.QoPlaylist.Tracks.Items)
                     {
                         if (abortToken.IsCancellationRequested) { abortToken.ThrowIfCancellationRequested(); }
@@ -1480,13 +1553,26 @@ namespace QobuzDownloaderX.Helpers
                             string track_id = item.Id.ToString();
                            
                             // [FETCH INFO] case "playlist" -> getTrackInfoLabels
-                            var playlistTrackInfoTask = Task.Run(() => f.getInfo.getTrackInfoLabels(f.app_id, track_id, f.user_auth_token));
-                            await RunTaskWithTimeoutAsync(f, playlistTrackInfoTask, getInfosTimeOut, "Q(Open)API 'getTrackInfoLabels' task has timed out.");
-                            f.QoItem = item;
-                            f.QoAlbum = f.getInfo.QoAlbum;
+                            GetInfo playlistTrackGetInfo = await ExecuteGetInfoTaskWithTimeoutAsync(
+                                f,
+                                getInfo => getInfo.getTrackInfoLabels(f.app_id, track_id, f.user_auth_token),
+                                getInfosTimeOut,
+                                "Q(Open)API 'getTrackInfoLabels' task has timed out.");
+                            f.QoItem = playlistTrackGetInfo.QoItem ?? item;
+                            f.QoAlbum = playlistTrackGetInfo.QoAlbum;
+
+                            if (f.QoItem != null)
+                            {
+                                f.QoItem.PlaylistTrackId = item.PlaylistTrackId;
+                                f.QoItem.Position = item.Position;
+                                if (Settings.Default.useItemPosInPlaylist)
+                                {
+                                    f.QoItem.TrackNumber = item.Position;
+                                }
+                            }
 
                             // [DOWNLOAD] case "playlist" -> DownloadPlaylistTrackAsync
-                            await Task.Run(() => f.downloadTrack.DownloadPlaylistTrackAsync(linkType,
+                            bool playlistTrackSucceeded = await Task.Run(() => f.downloadTrack.DownloadPlaylistTrackAsync(linkType,
                                 f.app_id, f.format_id, f.audio_format, f.user_auth_token, f.app_secret,
                                 f.downloadLocation, f.trackTemplate, f.playlistTemplate, f.QoAlbum, f.QoItem, f.QoPlaylist,
                                 new Progress<int>(value =>
@@ -1494,9 +1580,14 @@ namespace QobuzDownloaderX.Helpers
                                     double scaledValue = (trackIndexPlaylist - 1 + value / 100.0) / totalTracksPlaylist * 100.0;
                                     f.progressBarDownload.Invoke(new Action(() => f.progressBarDownload.Value = Math.Min(100, (int)Math.Round(scaledValue))));
                                 }), stats, abortToken));
+                            if (!playlistTrackSucceeded)
+                            {
+                                playlistSucceeded = false;
+                            }
                         }
                         catch
                         {
+                            playlistSucceeded = false;
                             continue;
                         }
                         if (!qbdlxForm.isBatchDownloadRunning) TaskbarHelper.SetProgressValue(trackIndexPlaylist, totalTracksPlaylist);
@@ -1505,9 +1596,16 @@ namespace QobuzDownloaderX.Helpers
                     }
                     if (abortToken.IsCancellationRequested) { abortToken.ThrowIfCancellationRequested(); }
                    
-                    // Say the downloading is finished when it's completed.
-                    f.getInfo.outputText = qbdlxForm._qbdlxForm.downloadOutput.Text;
-                    f.getInfo.updateDownloadOutput("\r\n" + f.downloadOutputCompleted);
+                    if (playlistSucceeded)
+                    {
+                        // Say the downloading is finished when it's completed.
+                        f.getInfo.outputText = qbdlxForm._qbdlxForm.downloadOutput.Text;
+                        f.getInfo.updateDownloadOutput("\r\n" + f.downloadOutputCompleted);
+                    }
+                    else if (!qbdlxForm.isBatchDownloadRunning)
+                    {
+                        TaskbarHelper.SetProgressState(TaskbarProgressState.Error);
+                    }
                     f.progressLabel.Invoke(new Action(() => f.progressLabel.Text = f.progressLabelInactive));
                     break;
 
@@ -1516,14 +1614,18 @@ namespace QobuzDownloaderX.Helpers
                     if (!qbdlxForm.isBatchDownloadRunning) TaskbarHelper.SetProgressValue(0, f.progressBarDownload.Maximum);
 
                     // [FETCH INFO] case "artist" -> getArtistInfo
-                    var artistTask = Task.Run(() => f.getInfo.getArtistInfo(f.app_id, f.qobuz_id, f.user_auth_token));
+                    GetInfo artistGetInfo;
                     try
                     {
-                        await RunTaskWithTimeoutAsync(f, artistTask, getInfosTimeOut, "Q(Open)API 'getArtistInfo' task has timed out.");
+                        artistGetInfo = await ExecuteGetInfoTaskWithTimeoutAsync(
+                            f,
+                            getInfo => getInfo.getArtistInfo(f.app_id, f.qobuz_id, f.user_auth_token),
+                            getInfosTimeOut,
+                            "Q(Open)API 'getArtistInfo' task has timed out.");
                     }
                     catch { return; }
 
-                    f.QoArtist = f.getInfo.QoArtist;
+                    f.QoArtist = artistGetInfo.QoArtist;
                     if (f.QoArtist == null || f.QoArtist.Albums == null || f.QoArtist.Albums.Items == null)
                     {
                         string msg = string.Format(f.languageManager.GetTranslation("invalidUrl"), albumLink);
@@ -1537,6 +1639,7 @@ namespace QobuzDownloaderX.Helpers
 
                     int totalAlbumsArtist = f.QoArtist.Albums.Items.Count;
                     int albumIndexArtist = 0;
+                    bool artistSucceeded = true;
 
                     if (totalAlbumsArtist == 0)
                     {
@@ -1564,13 +1667,16 @@ namespace QobuzDownloaderX.Helpers
                             string album_id = item.Id.ToString();
                            
                             // [FETCH INFO] case "artist" -> getAlbumInfoLabels
-                            var artistAlbumInfoTask = Task.Run(() => f.getInfo.getAlbumInfoLabels(f.app_id, album_id, f.user_auth_token));
-                            await RunTaskWithTimeoutAsync(f, artistAlbumInfoTask, getInfosTimeOut, "Q(Open)API 'getAlbumInfoLabels' task has timed out.");
-                            f.QoAlbum = f.getInfo.QoAlbum;
+                            GetInfo artistAlbumGetInfo = await ExecuteGetInfoTaskWithTimeoutAsync(
+                                f,
+                                getInfo => getInfo.getAlbumInfoLabels(f.app_id, album_id, f.user_auth_token),
+                                getInfosTimeOut,
+                                "Q(Open)API 'getAlbumInfoLabels' task has timed out.");
+                            f.QoAlbum = artistAlbumGetInfo.QoAlbum;
                             updateAlbumInfoLabels(f, f.QoAlbum);
 
                             // [DOWNLOAD] case "artist" -> DownloadAlbumAsync
-                            await Task.Run(() => f.downloadAlbum.DownloadAlbumAsync(
+                            bool artistAlbumSucceeded = await Task.Run(() => f.downloadAlbum.DownloadAlbumAsync(
                                f.app_id, album_id, f.format_id, f.audio_format, f.user_auth_token, f.app_secret,
                                f.downloadLocation, f.artistTemplate, f.albumTemplate, f.trackTemplate, f.QoAlbum,
                                new Progress<int>(value =>
@@ -1578,19 +1684,30 @@ namespace QobuzDownloaderX.Helpers
                                    double scaledValue = ((albumIndexArtist - 1) + value / 100.0) / totalAlbumsArtist * 100.0;
                                    f.progressBarDownload.Invoke(new Action(() => f.progressBarDownload.Value = Math.Min(100, (int)Math.Round(scaledValue))));
                                }), artistTrackCounter, stats, abortToken));
+                            if (!artistAlbumSucceeded)
+                            {
+                                artistSucceeded = false;
+                            }
                         }
                         catch
                         {
+                            artistSucceeded = false;
                             continue;
                         }
                     }
                     if (abortToken.IsCancellationRequested) { abortToken.ThrowIfCancellationRequested(); }
                    
-                    // Say the downloading is finished when it's completed.
                     if (!qbdlxForm.isBatchDownloadRunning) TaskbarHelper.SetProgressValue(albumIndexArtist, totalAlbumsArtist);
                     f.progressItemsCountLabel.Text = $"{f.languageManager.GetTranslation("artist")} | {f.languageManager.GetTranslation("album")} {albumIndexArtist:N0}/{totalAlbumsArtist:N0} {f.languageManager.GetTranslation("completed")}";
-                    f.getInfo.outputText = qbdlxForm._qbdlxForm.downloadOutput.Text;
-                    f.getInfo.updateDownloadOutput("\r\n" + f.downloadOutputCompleted);
+                    if (artistSucceeded)
+                    {
+                        f.getInfo.outputText = qbdlxForm._qbdlxForm.downloadOutput.Text;
+                        f.getInfo.updateDownloadOutput("\r\n" + f.downloadOutputCompleted);
+                    }
+                    else if (!qbdlxForm.isBatchDownloadRunning)
+                    {
+                        TaskbarHelper.SetProgressState(TaskbarProgressState.Error);
+                    }
                     f.progressLabel.Invoke(new Action(() => f.progressLabel.Text = f.progressLabelInactive));
                     break;
 
@@ -1599,16 +1716,21 @@ namespace QobuzDownloaderX.Helpers
                     if (!qbdlxForm.isBatchDownloadRunning) TaskbarHelper.SetProgressValue(0, f.progressBarDownload.Maximum);
 
                     // [FETCH INFO] case "label" -> getLabelInfo
-                    var labelTask = Task.Run(() => f.getInfo.getLabelInfo(f.app_id, f.qobuz_id, f.user_auth_token));
+                    GetInfo labelGetInfo;
                     try
                     {
-                        await RunTaskWithTimeoutAsync(f, labelTask, getInfosTimeOut, "Q(Open)API 'getLabelInfo' task has timed out.");
+                        labelGetInfo = await ExecuteGetInfoTaskWithTimeoutAsync(
+                            f,
+                            getInfo => getInfo.getLabelInfo(f.app_id, f.qobuz_id, f.user_auth_token),
+                            getInfosTimeOut,
+                            "Q(Open)API 'getLabelInfo' task has timed out.");
                     }
                     catch { return; }
 
-                    f.QoLabel = f.getInfo.QoLabel;
+                    f.QoLabel = labelGetInfo.QoLabel;
                     int totalAlbumsLabel = f.QoLabel.Albums.Items.Count;
                     int albumIndexLabel = 0;
+                    bool labelSucceeded = true;
 
                     if (totalAlbumsLabel == 0)
                     {
@@ -1636,13 +1758,16 @@ namespace QobuzDownloaderX.Helpers
                             string album_id = item.Id.ToString();
 
                             // [FETCH INFO] case "label" -> getAlbumInfoLabels
-                            var labelAlbumInfoTask = Task.Run(() => f.getInfo.getAlbumInfoLabels(f.app_id, album_id, f.user_auth_token));
-                            await RunTaskWithTimeoutAsync(f, labelAlbumInfoTask, getInfosTimeOut, "Q(Open)API 'getAlbumInfoLabels' task has timed out.");
-                            f.QoAlbum = f.getInfo.QoAlbum;
+                            GetInfo labelAlbumGetInfo = await ExecuteGetInfoTaskWithTimeoutAsync(
+                                f,
+                                getInfo => getInfo.getAlbumInfoLabels(f.app_id, album_id, f.user_auth_token),
+                                getInfosTimeOut,
+                                "Q(Open)API 'getAlbumInfoLabels' task has timed out.");
+                            f.QoAlbum = labelAlbumGetInfo.QoAlbum;
                             updateAlbumInfoLabels(f, f.QoAlbum);
 
                             // [DOWNLOAD] case "label" -> DownloadAlbumAsync
-                            await Task.Run(() => f.downloadAlbum.DownloadAlbumAsync(
+                            bool labelAlbumSucceeded = await Task.Run(() => f.downloadAlbum.DownloadAlbumAsync(
                                 f.app_id, album_id, f.format_id, f.audio_format, f.user_auth_token, f.app_secret,
                                 f.downloadLocation, f.artistTemplate, f.albumTemplate, f.trackTemplate, f.QoAlbum,
                                 new Progress<int>(value =>
@@ -1650,9 +1775,14 @@ namespace QobuzDownloaderX.Helpers
                                     double scaledValue = ((albumIndexLabel - 1) + value / 100.0) / totalAlbumsLabel * 100.0;
                                     f.progressBarDownload.Invoke(new Action(() => f.progressBarDownload.Value = Math.Min(100, (int)Math.Round(scaledValue))));
                                 }), labelTrackCounter, stats, abortToken));
+                            if (!labelAlbumSucceeded)
+                            {
+                                labelSucceeded = false;
+                            }
                         }
                         catch
                         {
+                            labelSucceeded = false;
                             continue;
                         }
                         if (!qbdlxForm.isBatchDownloadRunning) TaskbarHelper.SetProgressValue(albumIndexLabel, totalAlbumsLabel);
@@ -1660,30 +1790,41 @@ namespace QobuzDownloaderX.Helpers
                     }
                     if (abortToken.IsCancellationRequested) { abortToken.ThrowIfCancellationRequested(); }
                    
-                    // Say the downloading is finished when it's completed.
-                    f.getInfo.outputText = qbdlxForm._qbdlxForm.downloadOutput.Text;
-                    f.getInfo.updateDownloadOutput("\r\n" + f.downloadOutputCompleted);
+                    if (labelSucceeded)
+                    {
+                        // Say the downloading is finished when it's completed.
+                        f.getInfo.outputText = qbdlxForm._qbdlxForm.downloadOutput.Text;
+                        f.getInfo.updateDownloadOutput("\r\n" + f.downloadOutputCompleted);
+                    }
+                    else if (!qbdlxForm.isBatchDownloadRunning)
+                    {
+                        TaskbarHelper.SetProgressState(TaskbarProgressState.Error);
+                    }
                     f.progressLabel.Invoke(new Action(() => f.progressLabel.Text = f.progressLabelInactive));
                     break;
 
                 case "user":
+                    bool userOperationSucceeded = true;
                     if (qobuzLinkId.Contains("albums"))
                     {
                         f.skipButton.Enabled = true;
                         if (!qbdlxForm.isBatchDownloadRunning) TaskbarHelper.SetProgressValue(0, f.progressBarDownload.Maximum);
 
                         // [FETCH INFO] case "user" ("albums") -> getFavoritesInfo
-                        var userFavAlbumsTask = Task.Run(() => f.getInfo.getFavoritesInfo(f.app_id, f.user_id, "albums", f.user_auth_token));
+                        GetInfo userFavAlbumsGetInfo;
                         try
                         {
-                            await RunTaskWithTimeoutAsync(f, userFavAlbumsTask, getInfosTimeOut, "Q(Open)API 'getFavoritesInfo' task has timed out.");
+                            userFavAlbumsGetInfo = await ExecuteGetInfoTaskWithTimeoutAsync(
+                                f,
+                                getInfo => getInfo.getFavoritesInfo(f.app_id, f.user_id, "albums", f.user_auth_token),
+                                getInfosTimeOut,
+                                "Q(Open)API 'getFavoritesInfo' task has timed out.");
                         }
                         catch { return; }
 
-                        f.QoFavorites = f.getInfo.QoFavorites;
+                        f.QoFavorites = userFavAlbumsGetInfo.QoFavorites;
                         int totalAlbumsUser = f.QoFavorites.Albums.Items.Count;
                         int albumIndexUser = 0;
-
                         if (totalAlbumsUser == 0)
                         {
                             f.progressItemsCountLabel.Text = $"{f.languageManager.GetTranslation("user")} | 0 {f.languageManager.GetTranslation("albums")}";
@@ -1710,13 +1851,16 @@ namespace QobuzDownloaderX.Helpers
                                 string album_id = item.Id.ToString();
 
                                 // [FETCH INFO] case "user" ("albums") -> getAlbumInfoLabels
-                                var userAlbumInfoTask = Task.Run(() => f.getInfo.getAlbumInfoLabels(f.app_id, album_id, f.user_auth_token));
-                                await RunTaskWithTimeoutAsync(f, userAlbumInfoTask, getInfosTimeOut, "Q(Open)API 'getAlbumInfoLabels' task has timed out.");
-                                f.QoAlbum = f.getInfo.QoAlbum;
+                                GetInfo userAlbumGetInfo = await ExecuteGetInfoTaskWithTimeoutAsync(
+                                    f,
+                                    getInfo => getInfo.getAlbumInfoLabels(f.app_id, album_id, f.user_auth_token),
+                                    getInfosTimeOut,
+                                    "Q(Open)API 'getAlbumInfoLabels' task has timed out.");
+                                f.QoAlbum = userAlbumGetInfo.QoAlbum;
                                 updateAlbumInfoLabels(f, f.QoAlbum);
 
                                 // [DOWNLOAD] case "user" ("albums") -> DownloadAlbumAsync
-                                await Task.Run(() => f.downloadAlbum.DownloadAlbumAsync(
+                                bool userAlbumSucceeded = await Task.Run(() => f.downloadAlbum.DownloadAlbumAsync(
                                     f.app_id, album_id, f.format_id, f.audio_format, f.user_auth_token, f.app_secret,
                                     f.downloadLocation, f.artistTemplate, f.albumTemplate, f.trackTemplate, f.QoAlbum,
                                     new Progress<int>(value =>
@@ -1725,12 +1869,22 @@ namespace QobuzDownloaderX.Helpers
                                         f.progressBarDownload.Invoke(new Action(() => f.progressBarDownload.Value = Math.Min(100, (int)Math.Round(scaledValue))));
                                         if (!qbdlxForm.isBatchDownloadRunning) TaskbarHelper.SetProgressValue(f.progressBarDownload.Value, f.progressBarDownload.Maximum);
                                     }), userAlbumTrackCounter, stats, abortToken));
+                                if (!userAlbumSucceeded)
+                                {
+                                    userOperationSucceeded = false;
+                                }
                             }
                             catch
                             {
+                                userOperationSucceeded = false;
                                 continue;
                             }
                             f.progressItemsCountLabel.Text = $"{f.languageManager.GetTranslation("user")} | {f.languageManager.GetTranslation("album")} {albumIndexUser:N0}/{totalAlbumsUser:N0} {f.languageManager.GetTranslation("completed")}";
+                        }
+
+                        if (!userOperationSucceeded && !qbdlxForm.isBatchDownloadRunning)
+                        {
+                            TaskbarHelper.SetProgressState(TaskbarProgressState.Error);
                         }
                     }
                     else if (qobuzLinkId.Contains("tracks"))
@@ -1739,17 +1893,20 @@ namespace QobuzDownloaderX.Helpers
                         if (!qbdlxForm.isBatchDownloadRunning) TaskbarHelper.SetProgressValue(0, f.progressBarDownload.Maximum);
 
                         // [FETCH INFO] case "user" ("tracks") -> getFavoritesInfo
-                        var userFavTracksTask = Task.Run(() => f.getInfo.getFavoritesInfo(f.app_id, f.user_id, "tracks", f.user_auth_token));
+                        GetInfo userFavTracksGetInfo;
                         try
                         {
-                            await RunTaskWithTimeoutAsync(f, userFavTracksTask, getInfosTimeOut, "Q(Open)API 'getFavoritesInfo' task has timed out.");
+                            userFavTracksGetInfo = await ExecuteGetInfoTaskWithTimeoutAsync(
+                                f,
+                                getInfo => getInfo.getFavoritesInfo(f.app_id, f.user_id, "tracks", f.user_auth_token),
+                                getInfosTimeOut,
+                                "Q(Open)API 'getFavoritesInfo' task has timed out.");
                         }
                         catch { return; }
 
-                        f.QoFavorites = f.getInfo.QoFavorites;
+                        f.QoFavorites = userFavTracksGetInfo.QoFavorites;
                         int totalTracksUser = f.QoFavorites.Tracks.Items.Count;
                         int trackIndexUser = 0;
-
                         if (totalTracksUser == 0)
                         {
                             f.progressItemsCountLabel.Text = $"{f.languageManager.GetTranslation("user")} | 0 {f.languageManager.GetTranslation("tracks")}";
@@ -1767,14 +1924,17 @@ namespace QobuzDownloaderX.Helpers
                                 string track_id = item.Id.ToString();
 
                                 // [FETCH INFO] case "user" ("tracks") -> getTrackInfoLabels
-                                var userAlbumInfoTask = Task.Run(() => f.getInfo.getTrackInfoLabels(f.app_id, track_id, f.user_auth_token));
-                                await RunTaskWithTimeoutAsync(f, userAlbumInfoTask, getInfosTimeOut, "Q(Open)API 'getTrackInfoLabels' task has timed out.");
-                                f.QoItem = f.getInfo.QoItem;
-                                f.QoAlbum = f.getInfo.QoAlbum;
+                                GetInfo userTrackGetInfo = await ExecuteGetInfoTaskWithTimeoutAsync(
+                                    f,
+                                    getInfo => getInfo.getTrackInfoLabels(f.app_id, track_id, f.user_auth_token),
+                                    getInfosTimeOut,
+                                    "Q(Open)API 'getTrackInfoLabels' task has timed out.");
+                                f.QoItem = userTrackGetInfo.QoItem;
+                                f.QoAlbum = userTrackGetInfo.QoAlbum;
                                 updateAlbumInfoLabels(f, f.QoAlbum);
 
                                 // [DOWNLOAD] case "user" ("tracks") -> DownloadTrackAsync
-                                await Task.Run(() => f.downloadTrack.DownloadTrackAsync(
+                                bool userTrackSucceeded = await Task.Run(() => f.downloadTrack.DownloadTrackAsync(
                                     "track", f.app_id, track_id, f.format_id, f.audio_format, f.user_auth_token, f.app_secret,
                                     f.downloadLocation, f.artistTemplate, f.albumTemplate, f.trackTemplate, f.QoAlbum, f.QoItem,
                                     new Progress<int>(value =>
@@ -1782,13 +1942,23 @@ namespace QobuzDownloaderX.Helpers
                                         double scaledValue = ((trackIndexUser - 1) + value / 100.0) / totalTracksUser * 100.0;
                                         f.progressBarDownload.Invoke(new Action(() => f.progressBarDownload.Value = Math.Min(100, (int)Math.Round(scaledValue))));
                                     }), stats, abortToken));
+                                if (!userTrackSucceeded)
+                                {
+                                    userOperationSucceeded = false;
+                                }
                             }
                             catch
                             {
+                                userOperationSucceeded = false;
                                 continue;
                             }
                             if (!qbdlxForm.isBatchDownloadRunning) TaskbarHelper.SetProgressValue(trackIndexUser, totalTracksUser);
                             f.progressItemsCountLabel.Text = $"{f.languageManager.GetTranslation("user")} | {CultureInfo.CurrentCulture.TextInfo.ToTitleCase(f.languageManager.GetTranslation("track"))} {trackIndexUser:N0}/{totalTracksUser:N0} {f.languageManager.GetTranslation("completed")}";
+                        }
+
+                        if (!userOperationSucceeded && !qbdlxForm.isBatchDownloadRunning)
+                        {
+                            TaskbarHelper.SetProgressState(TaskbarProgressState.Error);
                         }
                     }
                     else if (qobuzLinkId.Contains("artists"))
@@ -1797,14 +1967,18 @@ namespace QobuzDownloaderX.Helpers
                         if (!qbdlxForm.isBatchDownloadRunning) TaskbarHelper.SetProgressValue(0, f.progressBarDownload.Maximum);
 
                         // [FETCH INFO] case "user" ("artists") -> getFavoritesInfo
-                        var userFavArtistsTask = Task.Run(() => f.getInfo.getFavoritesInfo(f.app_id, f.user_id, "artists", f.user_auth_token));
+                        GetInfo userFavArtistsGetInfo;
                         try
                         {
-                            await RunTaskWithTimeoutAsync(f, userFavArtistsTask, getInfosTimeOut, "Q(Open)API 'getFavoritesInfo' task has timed out.");
+                            userFavArtistsGetInfo = await ExecuteGetInfoTaskWithTimeoutAsync(
+                                f,
+                                getInfo => getInfo.getFavoritesInfo(f.app_id, f.user_id, "artists", f.user_auth_token),
+                                getInfosTimeOut,
+                                "Q(Open)API 'getFavoritesInfo' task has timed out.");
                         }
                         catch { return; }
 
-                        f.QoFavorites = f.getInfo.QoFavorites;
+                        f.QoFavorites = userFavArtistsGetInfo.QoFavorites;
 
                         int totalAlbumsUserArtists = 0;
                         int totalArtists = f.QoFavorites.Artists.Items.Count;
@@ -1825,10 +1999,13 @@ namespace QobuzDownloaderX.Helpers
                                 string artistId = artist.Id.ToString();
 
                                 // [FETCH INFO] case "user" ("artists") -> getArtistInfo
-                                var userArtistInfoTask = Task.Run(() => f.getInfo.getArtistInfo(f.app_id, artist.Id.ToString(), f.user_auth_token));
-                                await RunTaskWithTimeoutAsync(f, userArtistInfoTask, getInfosTimeOut, "Q(Open)API 'getArtistInfo' task has timed out.");
+                                GetInfo userArtistGetInfo = await ExecuteGetInfoTaskWithTimeoutAsync(
+                                    f,
+                                    getInfo => getInfo.getArtistInfo(f.app_id, artist.Id.ToString(), f.user_auth_token),
+                                    getInfosTimeOut,
+                                    "Q(Open)API 'getArtistInfo' task has timed out.");
 
-                                f.QoArtist = f.getInfo.QoArtist;
+                                f.QoArtist = userArtistGetInfo.QoArtist;
                                 artistInfoCache[artistId] = f.QoArtist;
 
                                 if (f.QoArtist.Albums != null )
@@ -1844,6 +2021,7 @@ namespace QobuzDownloaderX.Helpers
 
                         int albumIndexUserArtist = 0;
                         int indexUserArtist = 0;
+                        userOperationSucceeded = true;
 
                         foreach (var artist in f.QoFavorites.Artists.Items)
                         {
@@ -1880,13 +2058,16 @@ namespace QobuzDownloaderX.Helpers
                                         string album_id = artistItem.Id.ToString();
 
                                         // [FETCH INFO] case "user" ("artists") -> getAlbumInfoLabels
-                                        var userArtistAlbumInfoTask = Task.Run(() => f.getInfo.getAlbumInfoLabels(f.app_id, album_id, f.user_auth_token));
-                                        await RunTaskWithTimeoutAsync(f, userArtistAlbumInfoTask, getInfosTimeOut, "Q(Open)API 'getAlbumInfoLabels' task has timed out.");
-                                        f.QoAlbum = f.getInfo.QoAlbum;
+                                        GetInfo userArtistAlbumGetInfo = await ExecuteGetInfoTaskWithTimeoutAsync(
+                                            f,
+                                            getInfo => getInfo.getAlbumInfoLabels(f.app_id, album_id, f.user_auth_token),
+                                            getInfosTimeOut,
+                                            "Q(Open)API 'getAlbumInfoLabels' task has timed out.");
+                                        f.QoAlbum = userArtistAlbumGetInfo.QoAlbum;
                                         updateAlbumInfoLabels(f, f.QoAlbum);
 
                                         // [DOWNLOAD] case "user" ("artists") -> DownloadAlbumAsync
-                                        await Task.Run(() => f.downloadAlbum.DownloadAlbumAsync(
+                                        bool userArtistAlbumSucceeded = await Task.Run(() => f.downloadAlbum.DownloadAlbumAsync(
                                             f.app_id, album_id, f.format_id, f.audio_format, f.user_auth_token, f.app_secret, f.downloadLocation,
                                             f.artistTemplate, f.albumTemplate, f.trackTemplate, f.QoAlbum,
                                             new Progress<int>(value =>
@@ -1895,9 +2076,14 @@ namespace QobuzDownloaderX.Helpers
                                                 f.progressBarDownload.Invoke(new Action(() => f.progressBarDownload.Value = Math.Min(100, (int)Math.Round(scaledValue))));
                                                 if (!qbdlxForm.isBatchDownloadRunning) TaskbarHelper.SetProgressValue(f.progressBarDownload.Value, f.progressBarDownload.Maximum);
                                             }), userArtistTrackCounter, stats, abortToken));
+                                        if (!userArtistAlbumSucceeded)
+                                        {
+                                            userOperationSucceeded = false;
+                                        }
                                     }
                                     catch
                                     {
+                                        userOperationSucceeded = false;
                                         continue;
                                     }
                                 }
@@ -1905,6 +2091,7 @@ namespace QobuzDownloaderX.Helpers
                             }
                             catch
                             {
+                                userOperationSucceeded = false;
                                 continue;
                             }
                         }
@@ -1918,9 +2105,16 @@ namespace QobuzDownloaderX.Helpers
                         return;
                     }
                     if (abortToken.IsCancellationRequested) { abortToken.ThrowIfCancellationRequested(); }
-                    // Say the downloading is finished when it's completed.
-                    f.getInfo.outputText = qbdlxForm._qbdlxForm.downloadOutput.Text;
-                    f.getInfo.updateDownloadOutput("\r\n" + f.downloadOutputCompleted);
+                    if (userOperationSucceeded)
+                    {
+                        // Say the downloading is finished when it's completed.
+                        f.getInfo.outputText = qbdlxForm._qbdlxForm.downloadOutput.Text;
+                        f.getInfo.updateDownloadOutput("\r\n" + f.downloadOutputCompleted);
+                    }
+                    else if (!qbdlxForm.isBatchDownloadRunning)
+                    {
+                        TaskbarHelper.SetProgressState(TaskbarProgressState.Error);
+                    }
                     f.progressLabel.Invoke(new Action(() => f.progressLabel.Text = f.progressLabelInactive));
                     break;
                 default:

--- a/QobuzDownloaderX/Helpers/PaddingNumbers.cs
+++ b/QobuzDownloaderX/Helpers/PaddingNumbers.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Globalization;
 
 using QopenAPI;
 
@@ -8,46 +9,29 @@ namespace QobuzDownloaderX.Helpers
     {
         public Album QoAlbum = new Album();
 
+        private static int GetPaddingLength(int count)
+        {
+            if (count <= 0)
+            {
+                return 2;
+            }
+
+            return Math.Max(2, count.ToString(CultureInfo.InvariantCulture).Length);
+        }
+
         public int padTracks(Album QoAlbum)
         {
-
-            // Prepare track number padding in filename.
-            string paddingLog = Math.Floor(Math.Log10(QoAlbum.TracksCount) + 1).ToString();
-            switch (paddingLog)
-            {
-                case "1":
-                    return 2;
-                default:
-                    return (int)Math.Floor(Math.Log10(QoAlbum.TracksCount) + 1);
-            }
+            return GetPaddingLength(QoAlbum?.TracksCount ?? 0);
         }
 
         public int padPlaylistTracks(Playlist QoPlaylist)
         {
-
-            // Prepare track number padding in filename.
-            string paddingLog = Math.Floor(Math.Log10(QoPlaylist.TracksCount) + 1).ToString();
-            switch (paddingLog)
-            {
-                case "1":
-                    return 2;
-                default:
-                    return (int)Math.Floor(Math.Log10(QoPlaylist.TracksCount) + 1);
-            }
+            return GetPaddingLength(QoPlaylist?.TracksCount ?? 0);
         }
 
         public int padDiscs(Album QoAlbum)
         {
-
-            // Prepare track number padding in filename.
-            string paddingLog = Math.Floor(Math.Log10(QoAlbum.MediaCount) + 1).ToString();
-            switch (paddingLog)
-            {
-                case "1":
-                    return 2;
-                default:
-                    return (int)Math.Floor(Math.Log10(QoAlbum.MediaCount) + 1);
-            }
+            return GetPaddingLength(QoAlbum?.MediaCount ?? 0);
         }
     }
 }

--- a/QobuzDownloaderX/Helpers/RenameTemplates.cs
+++ b/QobuzDownloaderX/Helpers/RenameTemplates.cs
@@ -4,6 +4,7 @@ using QopenAPI;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -162,9 +163,20 @@ namespace QobuzDownloaderX.Helpers
         }
 
         [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "I don’t feel like changing this and it doesn’t matter")]
-        public string renameTemplates(string template, int paddedTrackLength, int paddedDiscLength, string fileFormat, Album QoAlbum, Item QoItem, Playlist QoPlaylist)
+        public string renameTemplates(
+            string template,
+            int paddedTrackLength,
+            int paddedDiscLength,
+            string fileFormat,
+            Album QoAlbum,
+            Item QoItem,
+            Playlist QoPlaylist,
+            string effectiveFormatId = null,
+            int? effectiveBitDepth = null,
+            double? effectiveSamplingRate = null)
         {
             qbdlxForm._qbdlxForm.logger.Debug("Renaming user template - " + template);
+            string selectedFormatId = effectiveFormatId ?? qbdlxForm._qbdlxForm.format_id;
 
             // Convert all text between % symbols to lowercase
             template = percentRegex.Replace(template, match => match.Value.ToLower());
@@ -181,6 +193,9 @@ namespace QobuzDownloaderX.Helpers
             // Track Templates
             if (QoItem != null)
             {
+                int trackBitDepth = effectiveBitDepth ?? QoItem.MaximumBitDepth;
+                double trackSamplingRate = effectiveSamplingRate ?? QoItem.MaximumSamplingRate;
+
                 if (QoAlbum != null)
                 {
                     string artistsNames = GetReleaseArtists(QoAlbum, updateAlbumInfoLabels: false) ?? "";
@@ -199,8 +214,8 @@ namespace QobuzDownloaderX.Helpers
                     .Replace("%trackcomposer%", QoItem?.Composer?.Name?.ToString())
                     .Replace("%tracknumber%", QoItem.TrackNumber.ToString().PadLeft(paddedTrackLength, '0'))
                     .Replace("%isrc%", QoItem.ISRC.ToString())
-                    .Replace("%trackbitdepth%", QoItem.MaximumBitDepth.ToString())
-                    .Replace("%tracksamplerate%", QoItem.MaximumSamplingRate.ToString());
+                    .Replace("%trackbitdepth%", trackBitDepth.ToString(CultureInfo.InvariantCulture))
+                    .Replace("%tracksamplerate%", trackSamplingRate.ToString("0.###", CultureInfo.InvariantCulture));
 
                 string titleFormatted = QoItem.Version == null
                                         ? QoItem.Title
@@ -221,12 +236,15 @@ namespace QobuzDownloaderX.Helpers
 
                 // Track Format Templates
                 template = template.Replace("%trackformat%", fileFormat.ToUpper().TrimStart('.'));
-                template = RenameFormatTemplate(template, qbdlxForm._qbdlxForm.format_id, fileFormat, QoItem.MaximumBitDepth, QoItem.MaximumSamplingRate, "%trackformatwithhiresquality%", "%trackformatwithquality%");
+                template = RenameFormatTemplate(template, selectedFormatId, fileFormat, trackBitDepth, trackSamplingRate, "%trackformatwithhiresquality%", "%trackformatwithquality%");
             }
 
             // Album Templates
             if (QoAlbum != null)
             {
+                int albumBitDepth = effectiveBitDepth ?? QoAlbum.MaximumBitDepth;
+                double albumSamplingRate = effectiveSamplingRate ?? QoAlbum.MaximumSamplingRate;
+
                 template = ReplaceParentalWarningTags(template, QoAlbum.ParentalWarning);
                 template = template
                     .Replace("%albumid%", QoAlbum.Id?.ToString() ?? "")
@@ -240,16 +258,26 @@ namespace QobuzDownloaderX.Helpers
                     .Replace("%releasedate%", QoAlbum.ReleaseDateOriginal?.Trim() ?? "")
                     .Replace("%year%", UInt32.Parse(QoAlbum.ReleaseDateOriginal?.Trim()?.Substring(0, 4)).ToString() ?? "")
                     .Replace("%releasetype%", char.ToUpper(QoAlbum.ProductType.FirstOrDefault()) + QoAlbum.ProductType?.Substring(1)?.ToLower())
-                    .Replace("%bitdepth%", QoAlbum.MaximumBitDepth.ToString() ?? "")
-                    .Replace("%samplerate%", QoAlbum.MaximumSamplingRate.ToString() ?? "")
+                    .Replace("%bitdepth%", albumBitDepth.ToString(CultureInfo.InvariantCulture))
+                    .Replace("%samplerate%", albumSamplingRate.ToString("0.###", CultureInfo.InvariantCulture))
                     .Replace("%albumtitle%", QoAlbum.Version == null ? QoAlbum.Title : $"{QoAlbum.Title?.TrimEnd()} ({QoAlbum.Version})")
                     .Replace("%format%", fileFormat.ToUpper().TrimStart('.'));
             }
 
             if (QoPlaylist == null)
             {
-                // Release Format Templates
-                template = RenameFormatTemplate(template, qbdlxForm._qbdlxForm.format_id, fileFormat, QoAlbum.MaximumBitDepth, QoAlbum.MaximumSamplingRate, "%formatwithhiresquality%", "%formatwithquality%");
+                if (QoAlbum != null)
+                {
+                    // Release Format Templates
+                    template = RenameFormatTemplate(
+                        template,
+                        selectedFormatId,
+                        fileFormat,
+                        effectiveBitDepth ?? QoAlbum.MaximumBitDepth,
+                        effectiveSamplingRate ?? QoAlbum.MaximumSamplingRate,
+                        "%formatwithhiresquality%",
+                        "%formatwithquality%");
+                }
             }
             else
             {
@@ -276,8 +304,8 @@ namespace QobuzDownloaderX.Helpers
                         .Replace("%releasedate%", QoAlbum.ReleaseDateOriginal?.Trim() ?? "")
                         .Replace("%year%", UInt32.Parse(QoAlbum.ReleaseDateOriginal?.Trim()?.Substring(0, 4)).ToString() ?? "")
                         .Replace("%releasetype%", char.ToUpper(QoAlbum.ProductType.FirstOrDefault()) + QoAlbum.ProductType?.Substring(1)?.ToLower())
-                        .Replace("%bitdepth%", QoAlbum.MaximumBitDepth.ToString() ?? "")
-                        .Replace("%samplerate%", QoAlbum.MaximumSamplingRate.ToString() ?? "")
+                        .Replace("%bitdepth%", (effectiveBitDepth ?? QoAlbum.MaximumBitDepth).ToString(CultureInfo.InvariantCulture))
+                        .Replace("%samplerate%", (effectiveSamplingRate ?? QoAlbum.MaximumSamplingRate).ToString("0.###", CultureInfo.InvariantCulture))
                         .Replace("%albumtitle%", QoAlbum.Version == null ? QoAlbum.Title : $"{QoAlbum.Title?.TrimEnd()} ({QoAlbum.Version})")
                         .Replace("%format%", fileFormat.ToUpper().TrimStart('.'));
                 }

--- a/QobuzDownloaderX/Helpers/RenameTemplates.cs
+++ b/QobuzDownloaderX/Helpers/RenameTemplates.cs
@@ -199,7 +199,10 @@ namespace QobuzDownloaderX.Helpers
                 if (QoAlbum != null)
                 {
                     string artistsNames = GetReleaseArtists(QoAlbum, updateAlbumInfoLabels: false) ?? "";
-                    if (variousArtistsNames.Any(name => artistsNames.Equals(name, StringComparison.OrdinalIgnoreCase)))
+                    bool isPlaylistDirectoryTemplate = QoPlaylist != null
+                        && template.IndexOf("%playlist", StringComparison.OrdinalIgnoreCase) >= 0;
+                    if (!isPlaylistDirectoryTemplate
+                        && variousArtistsNames.Any(name => artistsNames.Equals(name, StringComparison.OrdinalIgnoreCase)))
                     {
                         // Convert all text between % symbols to lowercase
                         template = percentRegex.Replace(Settings.Default.savedVaTrackTemplate, match => match.Value.ToLower());

--- a/QobuzDownloaderX/Helpers/RenameTemplates.cs
+++ b/QobuzDownloaderX/Helpers/RenameTemplates.cs
@@ -285,9 +285,16 @@ namespace QobuzDownloaderX.Helpers
                 template = template
                     .Replace("%playlistid%", QoPlaylist.Id.ToString())
                     .Replace("%playlisttitle%", QoPlaylist.Name)
-                    .Replace("%format%", fileFormat.ToUpper().TrimStart('.'))
-                    .Replace("%formatwithhiresquality%", fileFormat.ToUpper().TrimStart('.'))
-                    .Replace("%formatwithquality%", fileFormat.ToUpper().TrimStart('.')); 
+                    .Replace("%format%", fileFormat.ToUpper().TrimStart('.'));
+
+                template = RenameFormatTemplate(
+                    template,
+                    selectedFormatId,
+                    fileFormat,
+                    effectiveBitDepth ?? QoItem?.MaximumBitDepth ?? QoAlbum?.MaximumBitDepth ?? 0,
+                    effectiveSamplingRate ?? QoItem?.MaximumSamplingRate ?? QoAlbum?.MaximumSamplingRate ?? 0,
+                    "%formatwithhiresquality%",
+                    "%formatwithquality%");
 
                 if (QoItem != null)
                 {

--- a/QobuzDownloaderX/Helpers/SearchPanelHelper.cs
+++ b/QobuzDownloaderX/Helpers/SearchPanelHelper.cs
@@ -129,7 +129,7 @@ namespace QobuzDownloaderX.Helpers
                     {
                         SizeMode = PictureBoxSizeMode.StretchImage
                     };
-                    try { artwork.Load(album.Image.Large.ToString()); /* Using the thumbnail URL */ } catch { artwork.Image = Resources.qbdlx_new; /* Use QBDLX Icon as fallback */ }
+                    BeginLoadArtwork(artwork, album.Image?.Large?.ToString());
                     artwork.Width = 65;
                     artwork.Height = 65;
                     artwork.Anchor = AnchorStyles.None; // Center both horizontally and vertically
@@ -344,8 +344,7 @@ namespace QobuzDownloaderX.Helpers
                     {
                         SizeMode = PictureBoxSizeMode.StretchImage
                     };
-                    try { artwork.Load(track.Album.Image.Large.ToString()); /* Using the thumbnail URL */ }
-                    catch { artwork.Image = Resources.qbdlx_new; /* Use QBDLX Icon as fallback */ }
+                    BeginLoadArtwork(artwork, track.Album?.Image?.Large?.ToString());
                     artwork.Width = 65;
                     artwork.Height = 65;
                     artwork.Anchor = AnchorStyles.None; // Center both horizontally and vertically
@@ -530,10 +529,37 @@ namespace QobuzDownloaderX.Helpers
             }
             else if (control is PictureBox pictureBox)
             {
-                pictureBox.Image?.Dispose();
+                if (!ReferenceEquals(pictureBox.Image, Resources.qbdlx_new))
+                {
+                    pictureBox.Image?.Dispose();
+                }
             }
 
             control.Dispose();
+        }
+
+        private static void BeginLoadArtwork(PictureBox artwork, string imageUrl)
+        {
+            if (artwork == null) return;
+
+            artwork.WaitOnLoad = false;
+            artwork.InitialImage = Resources.qbdlx_new;
+            artwork.ErrorImage = Resources.qbdlx_new;
+            artwork.Image = Resources.qbdlx_new;
+
+            if (string.IsNullOrWhiteSpace(imageUrl))
+            {
+                return;
+            }
+
+            try
+            {
+                artwork.LoadAsync(imageUrl);
+            }
+            catch
+            {
+                artwork.Image = Resources.qbdlx_new;
+            }
         }
 
         /// <summary>

--- a/QobuzDownloaderX/Helpers/SecurityHelpers.cs
+++ b/QobuzDownloaderX/Helpers/SecurityHelpers.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace QobuzDownloaderX.Helpers
+{
+    internal static class SecurityHelpers
+    {
+        private static readonly Regex querySecretRegex = new Regex(
+            @"(?i)(?<key>app_secret|app_id|user_auth_token|password|token|request_sig|authorization|email)=(?<value>[^&\s]+)",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        private static readonly Regex jsonSecretRegex = new Regex(
+            "(?i)(?<prefix>\"(?:app_secret|app_id|user_auth_token|password|token|request_sig|authorization|email)\"\\s*:\\s*\")(?<value>[^\"]*)(?<suffix>\")",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        private static readonly Regex labeledSecretRegex = new Regex(
+            @"(?im)(?<label>\b(?:App secret|App ID|User auth token|Password|Email|Authorization)\b\s*:\s*)(?<value>.+)$",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        private static readonly Regex bearerTokenRegex = new Regex(
+            @"(?i)(?<prefix>\bBearer\s+)(?<value>[A-Za-z0-9\-._~+/=]+)",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        internal static string RedactSensitiveData(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                return input;
+            }
+
+            string redacted = querySecretRegex.Replace(input, match => $"{match.Groups["key"].Value}=<redacted>");
+            redacted = jsonSecretRegex.Replace(redacted, match => $"{match.Groups["prefix"].Value}<redacted>{match.Groups["suffix"].Value}");
+            redacted = labeledSecretRegex.Replace(redacted, match => $"{match.Groups["label"].Value}<redacted>");
+            redacted = bearerTokenRegex.Replace(redacted, match => $"{match.Groups["prefix"].Value}<redacted>");
+
+            return redacted;
+        }
+
+        internal static string MaskValue(string value, int visibleSuffixLength = 4)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return string.Empty;
+            }
+
+            if (visibleSuffixLength < 0)
+            {
+                visibleSuffixLength = 0;
+            }
+
+            if (value.Length <= visibleSuffixLength)
+            {
+                return new string('*', value.Length);
+            }
+
+            int maskedLength = Math.Max(4, value.Length - visibleSuffixLength);
+            return new string('*', maskedLength) + value.Substring(value.Length - visibleSuffixLength);
+        }
+
+        internal static Uri RequireHttpsUrl(string url, string context, Func<Uri, bool> additionalValidator = null)
+        {
+            if (!Uri.TryCreate(url, UriKind.Absolute, out Uri uri))
+            {
+                throw new InvalidOperationException($"{context} URL is invalid.");
+            }
+
+            if (!uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException($"{context} URL must use HTTPS.");
+            }
+
+            if (additionalValidator != null && !additionalValidator(uri))
+            {
+                throw new InvalidOperationException($"{context} URL host is not allowed.");
+            }
+
+            return uri;
+        }
+
+        internal static bool IsAllowedGitHubContentHost(Uri uri)
+        {
+            if (uri == null)
+            {
+                return false;
+            }
+
+            string host = uri.Host ?? string.Empty;
+
+            return host.Equals("api.github.com", StringComparison.OrdinalIgnoreCase)
+                || host.Equals("raw.githubusercontent.com", StringComparison.OrdinalIgnoreCase)
+                || host.Equals("objects.githubusercontent.com", StringComparison.OrdinalIgnoreCase)
+                || host.Equals("media.githubusercontent.com", StringComparison.OrdinalIgnoreCase)
+                || host.Equals("user-images.githubusercontent.com", StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static string EnsureTrailingDirectorySeparator(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return path;
+            }
+
+            return path.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal)
+                || path.EndsWith(Path.AltDirectorySeparatorChar.ToString(), StringComparison.Ordinal)
+                ? path
+                : path + Path.DirectorySeparatorChar;
+        }
+
+        internal static string EnsurePathIsWithinRoot(string rootPath, string candidatePath, string parameterName)
+        {
+            if (string.IsNullOrWhiteSpace(rootPath))
+            {
+                throw new ArgumentException("A root path is required.", nameof(rootPath));
+            }
+
+            if (string.IsNullOrWhiteSpace(candidatePath))
+            {
+                throw new ArgumentException("A candidate path is required.", parameterName);
+            }
+
+            string rootFullPath = Path.GetFullPath(rootPath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            string candidateFullPath = Path.GetFullPath(candidatePath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+            if (candidateFullPath.Equals(rootFullPath, StringComparison.OrdinalIgnoreCase))
+            {
+                return candidateFullPath;
+            }
+
+            string rootWithSeparator = rootFullPath + Path.DirectorySeparatorChar;
+            if (!candidateFullPath.StartsWith(rootWithSeparator, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException($"Resolved {parameterName} escapes the configured download directory.");
+            }
+
+            return candidateFullPath;
+        }
+
+        internal static string ResolveExecutablePath(string executablePathOrName)
+        {
+            if (string.IsNullOrWhiteSpace(executablePathOrName))
+            {
+                throw new ArgumentException("An executable path or file name is required.", nameof(executablePathOrName));
+            }
+
+            string trimmedExecutable = executablePathOrName.Trim().Trim('"');
+            var candidates = new List<string>();
+
+            if (Path.IsPathRooted(trimmedExecutable))
+            {
+                string rootedFullPath = Path.GetFullPath(trimmedExecutable);
+                if (File.Exists(rootedFullPath))
+                {
+                    return rootedFullPath;
+                }
+
+                throw new FileNotFoundException($"Executable not found: {rootedFullPath}", rootedFullPath);
+            }
+
+            string[] namesToSearch = Path.HasExtension(trimmedExecutable)
+                ? new[] { trimmedExecutable }
+                : new[] { trimmedExecutable, trimmedExecutable + ".exe" };
+
+            foreach (string fileName in namesToSearch)
+            {
+                candidates.Add(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, fileName));
+
+                string[] pathEntries = (Environment.GetEnvironmentVariable("PATH") ?? string.Empty)
+                    .Split(new[] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
+
+                foreach (string entry in pathEntries)
+                {
+                    string directory = entry.Trim().Trim('"');
+                    if (string.IsNullOrWhiteSpace(directory))
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        candidates.Add(Path.Combine(directory, fileName));
+                    }
+                    catch
+                    {
+                        // Ignore malformed PATH entries.
+                    }
+                }
+            }
+
+            foreach (string candidate in candidates
+                .Where(path => !string.IsNullOrWhiteSpace(path))
+                .Select(path => Path.GetFullPath(path))
+                .Distinct(StringComparer.OrdinalIgnoreCase))
+            {
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            throw new FileNotFoundException($"Executable '{trimmedExecutable}' was not found in the application directory or PATH.", trimmedExecutable);
+        }
+
+        internal static bool TryParseInt(string value, out int result)
+        {
+            return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
+        }
+
+        internal static bool TryParseDouble(string value, out double result)
+        {
+            return double.TryParse(value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out result);
+        }
+    }
+}

--- a/QobuzDownloaderX/Helpers/Theming.cs
+++ b/QobuzDownloaderX/Helpers/Theming.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
+using System.IO;
 using System.Windows.Forms;
 using ZetaLongPaths;
 
@@ -369,7 +370,7 @@ namespace QobuzDownloaderX.Helpers
     internal sealed class LanguageManager
     {
         private Dictionary<string, string> languageDictionary;
-        public string languagesDirectory = "languages";
+        public string languagesDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "languages");
 
         // Default English translation if no files are avaialble
         public const string defaultLanguage = @"{

--- a/QobuzDownloaderX/Helpers/Updating.cs
+++ b/QobuzDownloaderX/Helpers/Updating.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net.Http;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -12,6 +13,7 @@ namespace QobuzDownloaderX.Helpers
     internal sealed class TranslationUpdater
     {
         internal static readonly TimeSpan updateCheckTimeout = TimeSpan.FromSeconds(30);
+        private const int maxTranslationFileCharacters = 256 * 1024;
 
         static readonly Regex removeTimezoneRegEx = new Regex(@"[A-Z]{2,5}(\+?\d{0,2})?$", RegexOptions.Compiled);
 
@@ -30,13 +32,16 @@ namespace QobuzDownloaderX.Helpers
         public static string NormalizeDate(string dateStr)
         {
             // Remove any alphabetic timezone part
-            return removeTimezoneRegEx.Replace(dateStr, "").Trim();
+            return removeTimezoneRegEx.Replace(dateStr ?? string.Empty, "").Trim();
         }
 
         public static async Task CheckAndUpdateLanguageFiles()
         {
             try
             {
+                string localLanguagesDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "languages");
+                ZlpIOHelper.CreateDirectory(localLanguagesDirectory);
+
                 using (HttpClient client = new HttpClient() { Timeout = updateCheckTimeout })
                 {
                     client.DefaultRequestHeaders.Add("User-Agent", "TranslationUpdater");
@@ -44,9 +49,9 @@ namespace QobuzDownloaderX.Helpers
                     foreach (var languageFile in LanguageFiles)
                     {
                         string fileName = languageFile.Key;
-                        string localFilePath = languageFile.Value;
+                        string localFilePath = Path.Combine(localLanguagesDirectory, fileName.ToLowerInvariant());
 
-                        string apiUrl = $"https://api.github.com/repos/ImAiiR/QobuzDownloaderX/contents/QobuzDownloaderX/Resources/{localFilePath}";
+                        string apiUrl = $"https://api.github.com/repos/ImAiiR/QobuzDownloaderX/contents/QobuzDownloaderX/Resources/{languageFile.Value}";
 
                         try
                         {
@@ -60,17 +65,23 @@ namespace QobuzDownloaderX.Helpers
                                 string downloadUrl = fileMetadata["download_url"]?.ToString();
                                 if (!string.IsNullOrEmpty(downloadUrl))
                                 {
+                                    Uri downloadUri = SecurityHelpers.RequireHttpsUrl(downloadUrl, $"Translation update for {fileName}", SecurityHelpers.IsAllowedGitHubContentHost);
+
                                     // Fetch the remote file content
-                                    string remoteContent = await client.GetStringAsync(downloadUrl);
+                                    string remoteContent = await client.GetStringAsync(downloadUri);
+                                    if (remoteContent.Length > maxTranslationFileCharacters)
+                                    {
+                                        throw new InvalidOperationException($"Remote translation file '{fileName}' exceeded the maximum accepted size.");
+                                    }
 
                                     // Parse the "TranslationUpdatedOn" field from the remote file
                                     JObject remoteJson = JObject.Parse(remoteContent);
                                     string remoteUpdatedOnString = remoteJson["TranslationUpdatedOn"]?.ToString();
 
                                     // Parse the local file's "TranslationUpdatedOn" field
-                                    if (ZlpIOHelper.FileExists(localFilePath.ToLower()))
+                                    if (ZlpIOHelper.FileExists(localFilePath))
                                     {
-                                        string localContent = ZlpIOHelper.ReadAllText(localFilePath.ToLower());
+                                        string localContent = ZlpIOHelper.ReadAllText(localFilePath);
                                         JObject localJson = JObject.Parse(localContent);
                                         string localUpdatedOnString = localJson["TranslationUpdatedOn"]?.ToString();
 
@@ -80,7 +91,7 @@ namespace QobuzDownloaderX.Helpers
                                         {
                                             if (remoteDate > localDate)
                                             {
-                                                ZlpIOHelper.WriteAllText(localFilePath.ToLower(), remoteContent);
+                                                ZlpIOHelper.WriteAllText(localFilePath, remoteContent);
                                                 qbdlxForm._qbdlxForm.logger.Debug($"File {fileName} updated successfully.");
                                             }
                                             else
@@ -96,7 +107,7 @@ namespace QobuzDownloaderX.Helpers
                                     else
                                     {
                                         // Local file does not exist, download it
-                                        ZlpIOHelper.WriteAllText(localFilePath.ToLower(), remoteContent);
+                                        ZlpIOHelper.WriteAllText(localFilePath, remoteContent);
                                         qbdlxForm._qbdlxForm.logger.Debug($"File {fileName} downloaded successfully.");
                                     }
                                 }
@@ -151,6 +162,7 @@ namespace QobuzDownloaderX.Helpers
                     qbdlxForm._qbdlxForm.logger.Debug("Requesting latest GitHub release");
                     var versionUrl = "https://api.github.com/repos/ImAiiR/QobuzDownloaderX/releases/latest";
                     var response = await httpClient.GetAsync(versionUrl);
+                    response.EnsureSuccessStatusCode();
                     string responseString = await response.Content.ReadAsStringAsync();
 
                     // Parse the JSON response
@@ -165,8 +177,11 @@ namespace QobuzDownloaderX.Helpers
                     currentVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
 
                     // Compare versions numerically
-                    var newVersionObj = new Version(newVersion?.TrimStart('v')); // Remove leading 'v' if present
-                    var currentVersionObj = new Version(currentVersion);
+                    if (!Version.TryParse(newVersion?.TrimStart('v'), out Version newVersionObj) ||
+                        !Version.TryParse(currentVersion, out Version currentVersionObj))
+                    {
+                        throw new InvalidOperationException("Unable to parse version information returned by GitHub.");
+                    }
 
                     isUpdateAvailable = newVersionObj > currentVersionObj;
 

--- a/QobuzDownloaderX/QobuzDownloaderX.csproj
+++ b/QobuzDownloaderX/QobuzDownloaderX.csproj
@@ -79,16 +79,52 @@
     <Reference Include="Qo%28penAPI%29, Version=0.0.3.7, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>External References\Qo(penAPI).dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Bcl.HashCode, Version=6.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.HashCode.6.0.0\lib\net462\Microsoft.Bcl.HashCode.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="System">
       <HintPath>..\..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.8\System.dll</HintPath>
     </Reference>
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.6.1\lib\net462\System.Buffers.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Collections.Immutable, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.10.0.2\lib\net462\System.Collections.Immutable.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Formats.Nrbf, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Formats.Nrbf.10.0.2\lib\net462\System.Formats.Nrbf.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Memory, Version=4.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.6.3\lib\net462\System.Memory.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.6.1\lib\net462\System.Numerics.Vectors.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Reflection.Metadata, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.10.0.2\lib\net462\System.Reflection.Metadata.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Security" />
     <Reference Include="System.Resources.Extensions, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Resources.Extensions.10.0.2\lib\net462\System.Resources.Extensions.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.6.1\lib\net462\System.ValueTuple.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System.Windows.Forms" />

--- a/QobuzDownloaderX/QobuzDownloaderX.csproj
+++ b/QobuzDownloaderX/QobuzDownloaderX.csproj
@@ -30,6 +30,7 @@
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -86,6 +87,10 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Security" />
+    <Reference Include="System.Resources.Extensions, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Resources.Extensions.10.0.2\lib\net462\System.Resources.Extensions.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
@@ -103,6 +108,7 @@
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Helpers\BufferedLogger.cs" />
     <Compile Include="Helpers\FlexibleSettingsProvider.cs" />
+    <Compile Include="Helpers\SecurityHelpers.cs" />
     <Compile Include="Helpers\Download\DuplicateFileMode.cs" />
     <Compile Include="Helpers\Download\DownloadStats.cs" />
     <Compile Include="Helpers\Download\DownloadTrack.cs" />

--- a/QobuzDownloaderX/Tests/Smoke/Invoke-QbdlxSmoke.ps1
+++ b/QobuzDownloaderX/Tests/Smoke/Invoke-QbdlxSmoke.ps1
@@ -1,0 +1,161 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Email,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Password
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$binRoot = Join-Path $repoRoot "bin\Release"
+$exePath = Join-Path $binRoot "QobuzDownloaderX.exe"
+$qopenApiPath = Join-Path $binRoot "Qo(penAPI).dll"
+
+if (-not (Test-Path $exePath)) {
+    throw "Missing executable: $exePath"
+}
+
+if (-not (Test-Path $qopenApiPath)) {
+    throw "Missing QopenAPI DLL: $qopenApiPath"
+}
+
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 -bor 12288
+[Reflection.Assembly]::LoadFrom($qopenApiPath) | Out-Null
+
+function Get-StreamSummary {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$Service,
+
+        [Parameter(Mandatory = $true)]
+        [string]$AppId,
+
+        [Parameter(Mandatory = $true)]
+        [string]$UserAuthToken,
+
+        [Parameter(Mandatory = $true)]
+        [string]$AppSecret,
+
+        [Parameter(Mandatory = $true)]
+        [string]$TrackId,
+
+        [Parameter(Mandatory = $true)]
+        [string]$FormatId
+    )
+
+    $stream = $Service.TrackGetFileUrl($TrackId, $FormatId, $AppId, $UserAuthToken, $AppSecret)
+    if (-not $stream -or [string]::IsNullOrWhiteSpace($stream.StreamURL)) {
+        return [pscustomobject]@{
+            Requested  = $FormatId
+            Returned   = $null
+            MimeType   = $null
+            BitDepth   = $null
+            SampleRate = $null
+            Signature  = $null
+        }
+    }
+
+    $request = [Net.HttpWebRequest]::Create($stream.StreamURL)
+    $request.Method = "GET"
+    $request.AddRange(0, 3)
+    $request.Timeout = 30000
+    $response = $request.GetResponse()
+    try {
+        $buffer = New-Object byte[] 4
+        $read = $response.GetResponseStream().Read($buffer, 0, 4)
+        $signature = [BitConverter]::ToString($buffer, 0, $read)
+    }
+    finally {
+        $response.Close()
+    }
+
+    [pscustomobject]@{
+        Requested  = $FormatId
+        Returned   = [string]$stream.FormatID
+        MimeType   = [string]$stream.MimeType
+        BitDepth   = [string]$stream.BitDepth
+        SampleRate = [string]$stream.SampleRate
+        Signature  = $signature
+    }
+}
+
+$startupProcess = Start-Process -FilePath $exePath -WorkingDirectory $binRoot -PassThru -WindowStyle Hidden
+Start-Sleep -Seconds 10
+$startupPassed = -not $startupProcess.HasExited
+if ($startupPassed) {
+    Stop-Process -Id $startupProcess.Id -Force
+}
+
+$oldConsole = [Console]::Out
+[Console]::SetOut([IO.TextWriter]::Null)
+try {
+    $service = New-Object QopenAPI.Service
+    $appId = $service.GetAppID().App_ID
+    $user = $service.Login($appId, $Email, $Password, $null)
+    $appSecret = $service.GetAppSecret($appId, $user.UserAuthToken).App_Secret
+}
+finally {
+    [Console]::SetOut($oldConsole)
+}
+
+$sourceFiles = @{
+    DownloadAlbum = Join-Path $repoRoot "Helpers\Download\DownloadAlbum.cs"
+    DownloadTrack = Join-Path $repoRoot "Helpers\Download\DownloadTrack.cs"
+    DownloadFile = Join-Path $repoRoot "Helpers\Download\DownloadFile.cs"
+    Misc = Join-Path $repoRoot "Helpers\Miscellaneous.cs"
+    Search = Join-Path $repoRoot "Helpers\SearchPanelHelper.cs"
+    Rename = Join-Path $repoRoot "Helpers\RenameTemplates.cs"
+    GetInfo = Join-Path $repoRoot "Helpers\GetInfo.cs"
+    Padding = Join-Path $repoRoot "Helpers\PaddingNumbers.cs"
+}
+
+$source = @{}
+foreach ($entry in $sourceFiles.GetEnumerator()) {
+    $source[$entry.Key] = Get-Content $entry.Value -Raw
+}
+
+$sourceChecks = [ordered]@{
+    PaddingFixed = $source.DownloadAlbum.Contains("paddedDiscLength = padNumber.padDiscs(QoAlbum);")
+    PaddingSafeForZero = $source.Padding.Contains("return GetPaddingLength(QoPlaylist?.TracksCount ?? 0);") -and $source.Padding.Contains("return GetPaddingLength(QoAlbum?.MediaCount ?? 0);")
+    PlaylistMergeFixed = $source.Misc.Contains("f.QoItem = playlistTrackGetInfo.QoItem ?? item;")
+    AsyncArtworkFixed = $source.Search.Contains("artwork.LoadAsync(imageUrl);")
+    PlaylistQualityFixed = $source.Rename.Contains("template = RenameFormatTemplate(") -and $source.Rename.Contains("%formatwithquality%")
+    PlaylistTemplateGuard = $source.Rename.Contains("isPlaylistDirectoryTemplate")
+    TimeoutTokenGuard = $source.GetInfo.Contains("public CancellationToken UiCancellationToken") -and $source.Misc.Contains("TryCancelUiUpdates")
+    CompletionGuards = $source.Misc.Contains("if (albumSucceeded)") -and $source.Misc.Contains("if (trackSucceeded)") -and $source.Misc.Contains("if (playlistSucceeded)") -and $source.Misc.Contains("if (artistSucceeded)") -and $source.Misc.Contains("if (labelSucceeded)") -and $source.Misc.Contains("if (userOperationSucceeded)")
+    BoolReturnFlow = $source.DownloadAlbum.Contains("internal async Task<bool> DownloadAlbumAsync") -and $source.DownloadAlbum.Contains("internal async Task<bool> DownloadTracksAsync") -and $source.DownloadTrack.Contains("public async Task<bool> DownloadTrackAsync") -and $source.DownloadTrack.Contains("public async Task<bool> DownloadPlaylistTrackAsync") -and $source.DownloadFile.Contains("public async Task<bool> DownloadStream(")
+}
+
+$sourceChecks.Passed = ($sourceChecks.GetEnumerator() | Where-Object { $_.Value -is [bool] } | Where-Object { -not $_.Value }).Count -eq 0
+
+$result = [ordered]@{
+    Startup = [pscustomobject]@{
+        Passed = $startupPassed
+        ProcessId = $startupProcess.Id
+    }
+    Login = [pscustomobject]@{
+        Passed = [bool]$user
+        DisplayName = $user.UserInfo.DisplayName
+        Subscription = $user.UserInfo.Credential.Label
+        HiRes = [bool]$user.UserInfo.Credential.Parameters.HiResStreaming
+    }
+    Streams = [pscustomobject]@{
+        Track13176083 = @(
+            Get-StreamSummary -Service $service -AppId $appId -UserAuthToken $user.UserAuthToken -AppSecret $appSecret -TrackId "13176083" -FormatId "27"
+            Get-StreamSummary -Service $service -AppId $appId -UserAuthToken $user.UserAuthToken -AppSecret $appSecret -TrackId "13176083" -FormatId "7"
+            Get-StreamSummary -Service $service -AppId $appId -UserAuthToken $user.UserAuthToken -AppSecret $appSecret -TrackId "13176083" -FormatId "6"
+            Get-StreamSummary -Service $service -AppId $appId -UserAuthToken $user.UserAuthToken -AppSecret $appSecret -TrackId "13176083" -FormatId "5"
+        )
+        Track65115165 = @(
+            Get-StreamSummary -Service $service -AppId $appId -UserAuthToken $user.UserAuthToken -AppSecret $appSecret -TrackId "65115165" -FormatId "27"
+            Get-StreamSummary -Service $service -AppId $appId -UserAuthToken $user.UserAuthToken -AppSecret $appSecret -TrackId "65115165" -FormatId "6"
+            Get-StreamSummary -Service $service -AppId $appId -UserAuthToken $user.UserAuthToken -AppSecret $appSecret -TrackId "65115165" -FormatId "5"
+        )
+    }
+    SourceChecks = $sourceChecks
+}
+
+$result | ConvertTo-Json -Compress -Depth 6

--- a/QobuzDownloaderX/UI/LoginForm/LoginForm.cs
+++ b/QobuzDownloaderX/UI/LoginForm/LoginForm.cs
@@ -62,6 +62,18 @@ namespace QobuzDownloaderX
         readonly string errorLog = Path.GetDirectoryName(Application.ExecutablePath) + "\\Latest_Error.log";
         readonly string dllCheck = Path.GetDirectoryName(Application.ExecutablePath) + "\\taglib-sharp.dll";
 
+        private static string ProtectSettingValue(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return string.Empty;
+            }
+
+            byte[] bytes = Encoding.UTF8.GetBytes(value);
+            byte[] protectedBytes = ProtectedData.Protect(bytes, null, DataProtectionScope.CurrentUser);
+            return Convert.ToBase64String(protectedBytes);
+        }
+
         private void UpdateUILanguage()
         {
             // Load the font name from the translation file
@@ -165,11 +177,15 @@ namespace QobuzDownloaderX
                 {
                     password = savedPassword;
                     passwordTextBox.Text = savedPassword;
+                    passwordTextBox.PasswordChar = '*';
+                    passwordTextBox.ForeColor = ColorTranslator.FromHtml(themeManager._currentTheme.TextBoxText);
                 }
                 catch (CryptographicException) // cannot decrypt (different machine/user)
                 {
                     password = savedPassword;
                     passwordTextBox.Text = savedPassword;
+                    passwordTextBox.PasswordChar = '*';
+                    passwordTextBox.ForeColor = ColorTranslator.FromHtml(themeManager._currentTheme.TextBoxText);
                     // password = "";
                     // passwordTextBox.Text = passwordPlaceholder;
                 }
@@ -274,9 +290,7 @@ namespace QobuzDownloaderX
             }
 
 #if DEBUG
-            logger.Info("Currently saved username: " + username);
-            logger.Info("Currently saved app ID: " + Settings.Default.savedAppID);
-            logger.Info("Currently saved app secret: " + Settings.Default.savedSecret);
+            logger.Debug("Saved credential fields were loaded into the login form.");
 #endif
         }
 
@@ -289,7 +303,7 @@ namespace QobuzDownloaderX
         private void InitializeLanguage()
         {
             languageManager = new LanguageManager();
-            languageManager.LoadLanguage($"languages/{Settings.Default.currentLanguage.ToLower()}.json");
+            languageManager.LoadLanguage(Path.Combine(languageManager.languagesDirectory, Settings.Default.currentLanguage.ToLower() + ".json"));
             UpdateUILanguage();
         }
 
@@ -505,31 +519,23 @@ namespace QobuzDownloaderX
             // Encrypt username
             try
             {
-                byte[] emailBytes = Encoding.UTF8.GetBytes(username);
-                byte[] protectedBytes = ProtectedData.Protect(emailBytes, null, DataProtectionScope.CurrentUser);
-
-                Settings.Default.savedEmail = Convert.ToBase64String(protectedBytes);
+                Settings.Default.savedEmail = ProtectSettingValue(username);
             }
-            catch
+            catch (Exception ex)
             {
-                // Fallback: store plain text
-                Settings.Default.savedEmail = username;
-                logger.Warning("Email encryption failed, storing it as plain text.");
+                Settings.Default.savedEmail = string.Empty;
+                logger.Error("Email encryption failed, so the value will not be persisted: " + ex.Message);
             }
 
             // Encrypt password
             try
             {
-                byte[] passwordBytes = Encoding.UTF8.GetBytes(password);
-                byte[] protectedBytes = ProtectedData.Protect(passwordBytes, null, DataProtectionScope.CurrentUser);
-
-                Settings.Default.savedPassword = Convert.ToBase64String(protectedBytes);
+                Settings.Default.savedPassword = ProtectSettingValue(password);
             }
-            catch
+            catch (Exception ex)
             {
-                // Fallback: store plain text
-                Settings.Default.savedPassword = password;
-                logger.Warning("Password encryption failed, storing it as plain text.");
+                Settings.Default.savedPassword = string.Empty;
+                logger.Error("Password encryption failed, so the value will not be persisted: " + ex.Message);
             }
 
             // Save to settings
@@ -559,7 +565,7 @@ namespace QobuzDownloaderX
                     logger.Debug("No saved/custom app ID given, will get a new ID from Qobuz");
                     // Grab app_id & login
                     app_id = QoService.GetAppID().App_ID;
-                    logger.Info("App ID: " + app_id);
+                    logger.Info("App ID acquired.");
 
                     if (Settings.Default.savedAltLoginValue == false)
                     {
@@ -590,7 +596,7 @@ namespace QobuzDownloaderX
 
                     // Set app_secret
                     app_secret = QoService.GetAppSecret(app_id, user_auth_token).App_Secret;
-                    logger.Info("App secret: " + app_secret);
+                    logger.Info("App secret acquired.");
 
                     // Re-enable login button, and send app_id & app_secret to QBDLX
                     loginButton.Invoke(new Action(() => loginButton.Enabled = true));
@@ -611,7 +617,7 @@ namespace QobuzDownloaderX
                     logger.Debug("Using saved/custom app ID and secret");
                     // Use user-provided app_id & login
                     app_id = appidTextBox.Text;
-                    logger.Info("App ID: " + app_id);
+                    logger.Info("App ID loaded from secure settings or user input.");
 
                     if (Settings.Default.savedAltLoginValue == false)
                     {
@@ -643,7 +649,7 @@ namespace QobuzDownloaderX
 
                     // Set user-provided app_secret
                     app_secret = appSecretTextBox.Text;
-                    logger.Info("App secret: " + app_secret);
+                    logger.Info("App secret loaded from secure settings or user input.");
 
                     // Re-enable login button, and send app_id & app_secret to QBDLX
                     loginButton.Invoke(new Action(() => loginButton.Enabled = true));
@@ -697,15 +703,16 @@ namespace QobuzDownloaderX
                     deduped = captured; // fallback
                 }
 
-                string loginError = ex.ToString();
+                string loginError = SecurityHelpers.RedactSensitiveData(ex.ToString());
+                string sanitizedCapturedOutput = SecurityHelpers.RedactSensitiveData(deduped);
                 logger.Error("Login failed, error listed below.");
-                logger.Error("Error:\r\n" + ex);
-                if (!string.IsNullOrWhiteSpace(deduped))
-                    logger.Error("Captured output:\r\n" + deduped);
+                logger.Error("Error:\r\n" + loginError);
+                if (!string.IsNullOrWhiteSpace(sanitizedCapturedOutput))
+                    logger.Error("Captured output:\r\n" + sanitizedCapturedOutput);
 
                 try
                 {
-                    File.WriteAllText(errorLog, loginError + "\r\nDLL output:\r\n" + deduped);
+                    File.WriteAllText(errorLog, loginError + "\r\nDLL output:\r\n" + sanitizedCapturedOutput);
                 }
                 catch
                 {
@@ -722,9 +729,9 @@ namespace QobuzDownloaderX
 
                 // Try to parse the last line as JSON to extract error & message
                 string messageToShow = loginError; // default fallback
-                if (!string.IsNullOrWhiteSpace(deduped))
+                if (!string.IsNullOrWhiteSpace(sanitizedCapturedOutput))
                 {
-                    var lines = deduped.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
+                    var lines = sanitizedCapturedOutput.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
                     string lastLine = lines.LastOrDefault()?.Trim();
 
                     if (!string.IsNullOrEmpty(lastLine))
@@ -742,13 +749,13 @@ namespace QobuzDownloaderX
                             }
                             else
                             {
-                                messageToShow = deduped; // fallback to captured output
+                                messageToShow = sanitizedCapturedOutput; // fallback to captured output
                             }
                         }
                         catch
                         {
                             // not JSON, just show captured output
-                            messageToShow = deduped;
+                            messageToShow = sanitizedCapturedOutput;
                         }
                     }
                 }
@@ -886,7 +893,11 @@ namespace QobuzDownloaderX
             {
                 // If "Yes" is clicked, open GitHub page and close QBDLX.
                 logger.Debug("Opening GitHub page for latest update");
-                Process.Start("https://github.com/ImAiiR/QobuzDownloaderX/releases/latest");
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = "https://github.com/ImAiiR/QobuzDownloaderX/releases/latest",
+                    UseShellExecute = true
+                });
                 logger.Debug("Exiting");
                 Application.Exit();
             }
@@ -929,16 +940,12 @@ namespace QobuzDownloaderX
                 {
                     try
                     {
-                        byte[] appIdBytes = Encoding.UTF8.GetBytes(appId);
-                        byte[] protectedBytes = ProtectedData.Protect(appIdBytes, null, DataProtectionScope.CurrentUser);
-
-                        Settings.Default.savedAppID = Convert.ToBase64String(protectedBytes);
+                        Settings.Default.savedAppID = ProtectSettingValue(appId);
                     }
-                    catch
+                    catch (Exception ex)
                     {
-                        // Fallback: store plain text
-                        Settings.Default.savedAppID = appId;
-                        logger.Warning("App ID encryption failed, storing it as plain text.");
+                        Settings.Default.savedAppID = string.Empty;
+                        logger.Error("App ID encryption failed, so the value will not be persisted: " + ex.Message);
                     }
                 }
 
@@ -951,16 +958,12 @@ namespace QobuzDownloaderX
                 {
                     try
                     {
-                        byte[] appSecretBytes = Encoding.UTF8.GetBytes(appSecret);
-                        byte[] protectedBytes = ProtectedData.Protect(appSecretBytes, null, DataProtectionScope.CurrentUser);
-
-                        Settings.Default.savedSecret = Convert.ToBase64String(protectedBytes);
+                        Settings.Default.savedSecret = ProtectSettingValue(appSecret);
                     }
-                    catch
+                    catch (Exception ex)
                     {
-                        // Fallback: store plain text
-                        Settings.Default.savedSecret = appSecret;
-                        logger.Warning("App secret encryption failed, storing it as plain text.");
+                        Settings.Default.savedSecret = string.Empty;
+                        logger.Error("App secret encryption failed, so the value will not be persisted: " + ex.Message);
                     }
                 }
 

--- a/QobuzDownloaderX/UI/MainForm/qbdlxForm.cs
+++ b/QobuzDownloaderX/UI/MainForm/qbdlxForm.cs
@@ -178,9 +178,10 @@ namespace QobuzDownloaderX
         internal qbdlxForm()
         {
             // Create new log file
-            Directory.CreateDirectory("logs");
+            string logsDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "logs");
+            Directory.CreateDirectory(logsDirectory);
 
-            logger = new BufferedLogger("logs\\QobuzDLX " + DateTime.Now.ToString("yyyy⧸MM⧸dd HH꞉mm꞉ss") + ".log");
+            logger = new BufferedLogger(Path.Combine(logsDirectory, "QobuzDLX " + DateTime.Now.ToString("yyyy⧸MM⧸dd HH꞉mm꞉ss") + ".log"));
             logger.Debug("Logger started, QBDLX form initialized!");
 
             InitializeComponent();


### PR DESCRIPTION
## Summary
This PR contains the local fixes already validated against real Qobuz account flows and end-to-end downloads.

## What is included
- Harden credential persistence and redact sensitive values from logs/error output.
- Constrain generated output paths and require HTTPS for remote downloads/updates.
- Prefer `LocalAppData` for user settings storage.
- Fix startup/runtime loading around `System.Resources.Extensions` and required copied assemblies.
- Improve track stream fallback (`27 -> 7 -> 6`) and use the actual returned stream metadata for naming.

## Tracking issues
- Closes #284
- Closes #285
- Closes #286
- Closes #287
- Closes #288
- References #289

## Validation
- Release build succeeded.
- Application startup validated after runtime fix.
- Security/path/network isolated checks passed.
- Real login/search/stream checks passed.
- End-to-end downloads passed for both fallback FLAC and full Hi-Res FLAC cases.